### PR TITLE
TPA-529: remove unused EDB repo definition after config change

### DIFF
--- a/roles/sys/repositories/tasks/os/Debian/edb-repositories.yml
+++ b/roles/sys/repositories/tasks/os/Debian/edb-repositories.yml
@@ -2,6 +2,26 @@
 
 # © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
 
+- name: Find existing EDB repositories
+  find:
+    paths: /etc/apt/sources.list.d/
+    patterns: 'edb-*.list'
+    file_type: "file"
+  register: existing_edb_repos
+
+- name: Remove unwanted EDB repositories
+  file:
+    name: "{{ item.path }}"
+    state: absent
+  loop: "{{ existing_edb_repos.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  vars:
+    # edb-repo.list => [edb, repo]
+    repo: "{{ item.path|basename|split('.')|first|split('-') }}"
+  when: >
+    repo[1] not in edb_repositories
+
 - name: Add EDB repository keys
   apt_key:
     url: "https://downloads.enterprisedb.com/{{ edb_repos_token }}/{{ item }}/gpg.key"

--- a/roles/sys/repositories/tasks/os/RedHat/repositories.yml
+++ b/roles/sys/repositories/tasks/os/RedHat/repositories.yml
@@ -293,6 +293,26 @@
     label: >-
       {{ repo.repo }}
 
+- name: Find existing EDB repositories
+  find:
+    paths: /etc/yum.repos.d/
+    patterns: 'enterprisedb-*.repo'
+    file_type: "file"
+  register: existing_edb_repos
+
+- name: Remove unwanted EDB repositories
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ existing_edb_repos.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  vars:
+    # enterprisedb-repo.repo => [enterprisedb, repo]
+    repo: "{{ item.path|basename|split('.')|first|split('-') }}"
+  when: >
+    repo[1] not in edb_repositories
+
 - name: Install EDB repositories for x86_64
   include_tasks: add-repository.yml
   with_items: "{{ edb_repositories }}"

--- a/roles/sys/repositories/tasks/os/SUSE/repositories.yml
+++ b/roles/sys/repositories/tasks/os/SUSE/repositories.yml
@@ -42,6 +42,26 @@
     repo: "{{ repos[r] }}"
   ignore_errors: true
 
+- name: Find existing EDB repositories
+  find:
+    paths: /etc/zypp/repos.d/
+    patterns: 'enterprisedb-*.repo'
+    file_type: "file"
+  register: existing_edb_repos
+
+- name: Remove unwanted EDB repositories
+  file:
+    name: "{{ item.path }}"
+    state: absent
+  loop: "{{ existing_edb_repos.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  vars:
+    # enterprisedb-repo-arch.repo => [enterprisedb, repo, arch]
+    repo: "{{ item.path|basename|split('.')|first|split('-') }}"
+  when: >
+    repo[1] not in edb_repositories
+
 - name: Install EDB repositories for x86_64
   zypper_repository:
     name: "{{ repo.name }}"


### PR DESCRIPTION
We need to ensure that EDB repos defined in the config file are the one added to the cluster nodes and that any change to the configuration file will be taken into account. removing a repo from config.yml should remove the definition on the node available repositories list the same way we do for legacy 2Q repositories.