### PR TITLE
Require Python 3.9+ when running bin/tpaexec

### DIFF
--- a/.github/actions/install-requirements/action.yml
+++ b/.github/actions/install-requirements/action.yml
@@ -7,7 +7,7 @@ inputs:
   python-version:  # id of input
     description: 'Python version'
     required: true
-    default: "3.6"
+    default: "3.9"
   architecture:
     required: true
     description: "CPU architecture"

--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -1117,11 +1117,6 @@ elif [[ -z ${PYTHON:-""} ]]; then
     fi
 fi
 
-if ! command -v $PYTHON
-then
-    error "TPA requires a version of python to continue"
-fi
-
 case "$command" in
     *help|info|version)
         # Let through some basic commands, info in particular, without
@@ -1129,9 +1124,15 @@ case "$command" in
         ;;
 
     *)
-        if [[ $(_python39_or_later) == "False" ]]; then
-            error "TPA requires Python 3.9+, but found only" \
-                "$(_python_version) ($(command -v $PYTHON))"
+        if command -v "$PYTHON" &>/dev/null; then
+            if [[ $(_python39_or_later) == "False" ]]; then
+                error "TPA requires Python 3.9+, but found only" \
+                    "$(_python_version) ($(command -v $PYTHON));" \
+                    "please set PYTHON=/path/to/python3 or install edb-python"
+            fi
+        else
+            error "TPA requires at least Python 3.9; please " \
+                "set PYTHON=/path/to/python3 or install edb-python"
         fi
         ;;
 esac

--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -1105,9 +1105,21 @@ esac
 # If we can find a venv located relative to TPA_DIR, we activate it as a
 # convenience.
 
-PYTHON=${PYTHON:=python3}
 if [[ -f $TPA_VENV/bin/activate ]]; then
     _activate_venv "$TPA_VENV"
+    PYTHON=python3
+elif [[ -z ${PYTHON:-""} ]]; then
+    EDB_PYTHON=/usr/libexec/edb-python39/bin/python3
+    if [ -f $EDB_PYTHON ]; then
+        PYTHON=$EDB_PYTHON
+    else
+        PYTHON=python3
+    fi
+fi
+
+if ! command -v $PYTHON
+then
+    error "TPA requires a version of python to continue"
 fi
 
 case "$command" in

--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -76,23 +76,27 @@ version() {
 }
 
 verify_checksums() {
-   python3 "$TPA_DIR"/lib/tpaexec/compare_checksums.py "$TPA_DIR" "$TPA_DIR"/checksums.json
+   $PYTHON "$TPA_DIR"/lib/tpaexec/compare_checksums.py "$TPA_DIR" "$TPA_DIR"/checksums.json
 }
 
 _python_version() {
-    python3 -c 'import sys; print("%d.%d.%d" % (sys.version_info[0:3]))'
+    $PYTHON -c 'import sys; print("%d.%d.%d" % (sys.version_info[0:3]))'
+}
+
+_python39_or_later() {
+    $PYTHON -c 'import sys; print(sys.version_info[0:2] >= (3, 9))'
 }
 
 _detect_venv() {
-    python3 -c "import sys; print('venv' if hasattr(sys, 'real_prefix') or sys.base_prefix != sys.prefix else 'no venv')"
+    $PYTHON -c "import sys; print('venv' if hasattr(sys, 'real_prefix') or sys.base_prefix != sys.prefix else 'no venv')"
 }
 
 _detect_site_packages() {
-    python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+    $PYTHON -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
 }
 
 _ansible_version() {
-    python3 -c 'import ansible.release; print(ansible.release.__version__)'
+    $PYTHON -c 'import ansible.release; print(ansible.release.__version__)'
 }
 
 _activate_venv() {
@@ -112,9 +116,9 @@ _create_and_activate_venv() {
         if ! mkdir -p "$vpath"; then
             error "couldn't create $vpath (try '--venv /other/path' or use sudo)"
         fi
-        if ! python3 -m venv "$vpath"; then
+        if ! $PYTHON -m venv "$vpath"; then
             rm -rf "$vpath"
-            error "couldn't initialise $vpath using 'python3 -m venv'"
+            error "couldn't initialise $vpath using '$PYTHON -m venv'"
         fi
     fi
 
@@ -461,9 +465,15 @@ _tpaexec_info() {
     echo tpaexec="$0"
     echo TPA_DIR="$TPA_DIR"
 
-    if command -v python3 &>/dev/null; then
-        echo -n PYTHON="$(command -v python3)"
-        echo " (v$(_python_version), $(_detect_venv))"
+    if command -v "$PYTHON" &>/dev/null; then
+        python_bin=$(command -v "$PYTHON")
+        if [[ $(_python39_or_later) == "True" ]]; then
+            echo -n PYTHON="$python_bin"
+            echo " (v$(_python_version), $(_detect_venv))"
+        else
+            echo -n PYTHON=none "(need 3.9+, won't use $python_bin"
+            echo " (v$(_python_version), $(_detect_venv)))"
+        fi
     else
         echo PYTHON=none
     fi
@@ -1095,9 +1105,24 @@ esac
 # If we can find a venv located relative to TPA_DIR, we activate it as a
 # convenience.
 
+PYTHON=${PYTHON:=python3}
 if [[ -f $TPA_VENV/bin/activate ]]; then
     _activate_venv "$TPA_VENV"
 fi
+
+case "$command" in
+    *help|info|version)
+        # Let through some basic commands, info in particular, without
+        # checking the Python version first.
+        ;;
+
+    *)
+        if [[ $(_python39_or_later) == "False" ]]; then
+            error "TPA requires Python 3.9+, but found only" \
+                "$(_python_version) ($(command -v $PYTHON))"
+        fi
+        ;;
+esac
 
 # Now we can look at the command-line arguments and decide which
 # function to call.

--- a/docs/src/INSTALL-docker.md
+++ b/docs/src/INSTALL-docker.md
@@ -3,7 +3,7 @@
 If you are using a system for which there are no [TPA
 packages](INSTALL.md) available, and it's difficult to run TPA after
 [installing from source](INSTALL-repo.md) (for example, because it's not
-easy to obtain a working Python 3.6+ interpreter), your last resort may
+easy to obtain a working Python 3.9+ interpreter), your last resort may
 be to build a Docker image and run TPA inside a Docker container.
 
 Please note that you do not need to run TPA in a Docker container in

--- a/docs/src/INSTALL-repo.md
+++ b/docs/src/INSTALL-repo.md
@@ -3,23 +3,23 @@
 This document explains how to use TPA from a copy of the source code
 repository.
 
-!!! Note 
+!!! Note
       EDB customers must [install TPA from packages](INSTALL.md) in
       order to receive EDB support for the software.
 
 To run TPA from source, you must install all of the dependencies
-(e.g., Python 3.6+) that the packages would handle for you, or download
+(e.g., Python 3.9+) that the packages would handle for you, or download
 the source and [run TPA in a Docker container](INSTALL-docker.md).
 (Either way will work fine on Linux and macOS.)
 
 ## Quickstart
 
-First, you must install the various dependencies Python 3, Python 
+First, you must install the various dependencies Python 3, Python
 venv, git, openvpn and patch. Installing from EDB repositories would
-would  install these automatically along with the TPA 
-packages.  
+would  install these automatically along with the TPA
+packages.
 
-Before you install TPA, you must install the required packages: 
+Before you install TPA, you must install the required packages:
 
 * **Debian/Ubuntu** <br/> `sudo apt-get install python3 python3-pip python3-venv git openvpn patch`
 * **Redhat, Rocky or AlmaLinux (RHEL7)** <br/> `sudo yum install python3 python3-pip epel-release git openvpn patch`
@@ -63,9 +63,9 @@ You now have tpaexec installed.
 
 ## Dependencies
 
-### Python 3.6+
+### Python 3.9+
 
-TPA requires Python 3.6 or later, available on most
+TPA requires Python 3.9 or later, available on most
 modern distributions. If you don't have it, you can use
 [pyenv](https://github.com/pyenv/pyenv) to install any version of Python
 you like without affecting the system packages.

--- a/docs/src/INSTALL.md
+++ b/docs/src/INSTALL.md
@@ -102,7 +102,7 @@ sudo yum install tpaexec
 ```
 
 This will install TPA into `/opt/EDB/TPA`. It will also
-ensure that other required packages (e.g., Python 3.6 or later) are
+ensure that other required packages (e.g., Python 3.9 or later) are
 installed.
 
 We mention `sudo` here only to indicate which commands need root

--- a/roles/selftest/tasks/main.yml
+++ b/roles/selftest/tasks/main.yml
@@ -6,11 +6,11 @@
   setup:
     gather_subset: min
 
-- name: Check for Python 3.6.x+ and Ansible 2.9.x
+- name: Check for Python 3.9.x+ and Ansible 2.9.x
   assert:
-    msg: "Python 3.6.x+ and Ansible 2.9.x are required"
+    msg: "Python 3.9.x+ and Ansible 2.9.x are required"
     that:
-      - ansible_facts.python_version is version('3.6', '>=')
+      - ansible_facts.python_version is version('3.9', '>=')
       - ansible_version.major == 2
       - ansible_version.minor == 9
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,3 +1,3 @@
 # This file is used by Dependabot to select runtime version of python it should
 # use to run and generate requirements files for its PRs.
-python-3.6.15
+python-3.9.16


### PR DESCRIPTION
We maintain backwards compatibility with Python 3.6 so far, because both
RHEL7 and RHEL8 have that version by default. But with the cryptography
module removing support for that version, and several pending security
alerts, we want to begin moving away from 3.6 ourselves.

This commit sets the stage for automatically discovering another Python
interpreter (e.g., from edb-python, if available) if the system's
default one is too old. Otherwise, if you initialise your venv with a
different interpreter, or another python is in your PATH, it should just
work sensibly without further ado.

References: TPA-562
