### PR TITLE
Use postgres binary instead of postmaster

### DIFF
--- a/roles/postgres/service/tasks/main.yml
+++ b/roles/postgres/service/tasks/main.yml
@@ -23,8 +23,8 @@
        '{{ postgres_service_name }}-monitor']
   register: unit
   vars:
-    _postmaster: "{{
-        '%s/%spostmaster' % (
+    _postgres: "{{
+        '%s/%spostgres' % (
           postgres_bin_dir,
           (postgres_flavour == 'epas')|ternary('edb-', '')
         )

--- a/roles/postgres/service/templates/postgres.service.j2
+++ b/roles/postgres/service/templates/postgres.service.j2
@@ -20,7 +20,7 @@ Environment={{ k }}={{ v }}
 {%   endfor %}
 {% endif %}
 StandardOutput=syslog
-ExecStart={{ _postmaster }} -D ${PGDATA} -c config_file={{ postgres_conf_dir }}/postgresql.conf
+ExecStart={{ _postgres }} -D ${PGDATA} -c config_file={{ postgres_conf_dir }}/postgresql.conf
 {% if postgres_coredump_filter is defined %}
 ExecStartPost=/bin/bash -c 'echo {{ postgres_coredump_filter }} > /proc/$MAINPID/coredump_filter'
 PermissionsStartOnly=true


### PR DESCRIPTION
Symbolic link for `postmaster` has been removed in pg16. Previous versions support the arguments to start the daemon.

References: TPA-547