### PR TITLE
Update `master` to `main` branch name change on new repo

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,12 +5,12 @@ name: Integration Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - review_requested
     branches:
-      - master
+      - main
   pull_request_review:
     types:
       - submitted
@@ -20,12 +20,12 @@ jobs:
 
   integration-test:
     # In addition to the event triggers above, this job only runs when any of these conditions are met:
-    #  * the branch is master
+    #  * the branch is main
     #  * review is requested from the tpaexec-dev-team on a PR for a branch starting with 'rc/'
     #  * review is marked as approved on a PR for a branch starting with 'rc/'
     #  * a manual run is executed
     if: >
-      github.ref_name == 'master'
+      github.ref_name == 'main'
       || (github.event.requested_team
           && github.event.requested_team.name == 'tpaexec-dev-team')
           && startsWith(github.event.pull_request.base.ref, 'rc/')

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -7,7 +7,7 @@ name: Python requirements file update
 on:
   push:
     branches-ignore:
-      - master
+      - main
       - dependabot/**
     paths:
       - requirements-ansible-*.in

--- a/.github/workflows/simple_integration_tests.yml
+++ b/.github/workflows/simple_integration_tests.yml
@@ -5,13 +5,13 @@ name: Simple Integration Tests
 on:
   push:
     branches-ignore:
-    - master
+    - main
     - 'rc/**'
   pull_request:
     types:
     - review_requested
     branches:
-    - master
+    - main
   pull_request_review:
     types:
     - submitted
@@ -27,7 +27,7 @@ jobs:
     if: >
       (github.event.requested_team && github.event.requested_team.name == 'tpaexec-dev-team') || (github.event.review
           && github.event.review.state == 'approved'
-          && startsWith(github.event.pull_request.base.ref, 'master'))
+          && startsWith(github.event.pull_request.base.ref, 'main'))
       || github.event_name == 'workflow_dispatch'
 
     name: Integration test

--- a/.github/workflows/simple_patroni_integration_tests.yml
+++ b/.github/workflows/simple_patroni_integration_tests.yml
@@ -13,7 +13,7 @@ on:
       - '**haproxy**'
       - '**watchdog**'
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,10 +5,10 @@ name: Unit Tests
 on:
   push:
     branches:
-        - master
+        - main
   pull_request:
     branches:
-        - master
+        - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As the master branch name changed to main during the repo change of tpa, we need to update the branch references in GitHub workflows. These jobs aren't triggering at the moment.