### PR TITLE
Enable apache on PEM servers

### DIFF
--- a/roles/pem/server/config/webserver/handlers/main.yml
+++ b/roles/pem/server/config/webserver/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+- name: Restart apache for pem
+  service:
+    name: "{{ pem_web_server_service_name[ansible_os_family] }}"
+    state: restarted
+  listen: Restart apache for pem

--- a/roles/pem/server/config/webserver/tasks/main.yml
+++ b/roles/pem/server/config/webserver/tasks/main.yml
@@ -29,6 +29,7 @@
     dest: "{{ pem_base_dir }}/web/pem.wsgi"
     backup: yes
     remote_src: yes
+  notify: Restart apache for pem
 
 - name: Generating PEM Cookie Name
   shell: hexdump -n 4 -e '4/4 "%08X" 1 "\n"' /dev/random | head -c 6
@@ -64,6 +65,7 @@
     executable: /bin/bash
   when: >
     (pem_web_server_renew_tls_certificates|default(false)) or (not pem_web_server_certificate.stat.exists)
+  notify: Restart apache for pem
 
 - name: "Install {{ pem_branding_edb_wl }}-pem.conf"
   template:
@@ -72,6 +74,7 @@
     owner: root
     group: root
     mode: 0644
+  notify: Restart apache for pem
   tags: [pem-server, pem-webserver]
 
 - include_tasks: pem_sites.yml
@@ -88,17 +91,12 @@
   service:
     name: "{{ pem_web_server_service_name[ansible_os_family] }}"
     enabled: yes
+    state: started
 
-# XXX: What triggers this restart? Is it the SELinux config?
-- name: "Restart httpd service - {{ pem_web_server_service_name[ansible_os_family] }}"
-  service:
-    name: "{{ pem_web_server_service_name[ansible_os_family] }}"
-    state: restarted
-
-- name: Webserever configured
+- name: Webserver configured
   debug:
     msg: >
-      Configured the webservice for "{{ pem_branding_edb_wl }}" Postgres
+      Configured the webserver for "{{ pem_branding_edb_wl }}" Postgres
       Enterprise Manager (PEM) Server on port "{{ pem_server_ssl_port }}"
 
 - name: PEM server access info

--- a/roles/pem/server/config/webserver/tasks/main.yml
+++ b/roles/pem/server/config/webserver/tasks/main.yml
@@ -84,6 +84,11 @@
 - name: Configure SELinux security policy for PEM
   command: "{{ pem_base_dir }}/bin/configure-selinux.sh"
 
+- name: Ensure web server is started on boot
+  service:
+    name: "{{ pem_web_server_service_name[ansible_os_family] }}"
+    enabled: yes
+
 # XXX: What triggers this restart? Is it the SELinux config?
 - name: "Restart httpd service - {{ pem_web_server_service_name[ansible_os_family] }}"
   service:

--- a/roles/pem/server/config/webserver/tasks/pem_sites.yml
+++ b/roles/pem/server/config/webserver/tasks/pem_sites.yml
@@ -11,13 +11,17 @@
         owner: root
         group: root
         mode: 0644
+      notify: Restart apache for pem
   become: yes
   tags: [pem-server, pem-webserver]
 
 - name: Enable ssl-pem configuration (Debian/Ubuntu)
   block:
     - name: "Enable the apache2 site: {{ pem_branding_edb_wl }}-ssl-pem.conf"
-      command: "/usr/sbin/a2ensite -m {{ pem_branding_edb_wl }}-ssl-pem"
+      command:
+        cmd: "/usr/sbin/a2ensite -m {{ pem_branding_edb_wl }}-ssl-pem"
+        creates: "/etc/apache2/sites-enabled/{{ pem_branding_edb_wl }}-ssl-pem.conf"
+      notify: Restart apache for pem
 
     - name: "Install {{ pem_branding_edb_wl }}-gnutls-pem.conf"
       template:
@@ -26,9 +30,13 @@
         owner: root
         group: root
         mode: 0644
+      notify: Restart apache for pem
 
     - name: "Enable the apache2 site: {{ pem_branding_edb_wl }}-gnutls-pem.conf"
-      command: "/usr/sbin/a2ensite -m {{ pem_branding_edb_wl }}-gnutls-pem"
+      command:
+        cmd: "/usr/sbin/a2ensite -m {{ pem_branding_edb_wl }}-gnutls-pem"
+        creates: "/etc/apache2/sites-enabled/{{ pem_branding_edb_wl }}-gnutls-pem.conf"
+      notify: Restart apache for pem
 
   when: ansible_os_family == 'Debian'
   become: yes


### PR DESCRIPTION
When installing and configuring apache on a PEM server, we need to enable it explicitly so that systems (currently RHEL) on which this isn't the default do the right thing.