### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,38 +15,48 @@
 #   tpaexec configure cluster -a M1 --postgresql 15 --failover-manager patroni --platform docker
 #   tpaexec deploy cluster
 
-FROM debian:latest
+FROM debian:bookworm-slim
 
 LABEL maintainer="EDB <tpa@enterprisedb.com>"
+
+# Copy tpaexec sources from the current directory into the image
+ENV TPA_DIR=/opt/EDB/TPA
+
+COPY . ${TPA_DIR}
 
 # Set up repositories and install packages, including the Docker CE CLI
 # (https://docs.docker.com/engine/install/debian/).
 
 RUN apt-get -y update && \
-    apt-get -y install curl gnupg apt-transport-https \
-      python3 python3-pip python3-venv openvpn patch git && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg >/etc/apt//trusted.gpg.d/docker.asc && \
+    apt-get -y install --no-install-recommends \
+      curl gnupg apt-transport-https \
+      python3 python3-pip python3-venv \
+      openvpn patch git && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg >/etc/apt/trusted.gpg.d/docker.asc && \
     codename=$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release) && \
     arch=$(dpkg --print-architecture) && \
     echo "deb [arch=$arch] https://download.docker.com/linux/debian $codename stable" \
       >/etc/apt/sources.list.d/docker.list && \
     apt-get -y update && \
-    apt-get -y install docker-ce-cli && \
-    rm -rf /var/cache/apt/
-
-# Copy tpaexec sources from the current directory into the image, and
-# run `tpaexec setup` to complete the installation, and then `tpaexec
-# selftest` to verify it.
-
-ENV TPA_DIR=/opt/EDB/TPA
-
-COPY . ${TPA_DIR}
-
-RUN ln -sf ${TPA_DIR}/bin/tpaexec /usr/local/bin && \
+    apt-get -y install --no-install-recommends docker-ce-cli && \
+    \
+    # run `tpaexec setup` to complete the installation, and then `tpaexec selftest` to verify it. \
+    \
+    ln -sf ${TPA_DIR}/bin/tpaexec /usr/local/bin && \
     mkdir /opt/2ndQuadrant/ && \
     ln -sf ${TPA_DIR} /opt/2ndQuadrant/TPA && \
     tpaexec setup --use-community-ansible && \
-    tpaexec selftest
+    tpaexec selftest && \
+    (cd "${TPA_DIR}" && git describe --tags >VERSION) && \
+    \
+    # Clean up unnecessary files and packages \
+    \
+    rm -rf ${TPA_DIR}/.[a-z]* && \
+    apt purge -y python3-pip python3-venv build-essential && \
+    apt autoremove -y && \
+    apt autoclean -y && \
+    apt clean -y && \
+    rm -rf /var/cache/apt /var/lib/apt/lists
 
 WORKDIR /work
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 #  docker build -t tpaexec:$(git describe --tags) -t tpaexec:latest .
 
-# Use the container image, create an like this
+# To use the container image, create a shell alias like this
 #
 #   alias tpaexec="docker run --rm -v $PWD:/work -v $HOME/.git:/root/.git -v $HOME/.gitconfig:/root/.gitconfig \
 #      -v /var/run/docker.sock:/var/run/docker.sock \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+# We should be in workdir
+/usr/local/bin/tpaexec "$@"
+res=$?
+[ -n "$USER_ID" ] && chown "$USER_ID" -R .
+[ -n "$GROUP_ID" ] && chgrp "$GROUP_ID" -R .
+exit "$res"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
 
-set -x
-
 reset_perms() {
     [ -n "$USER_ID" ] && chown "$USER_ID" -R /work
     [ -n "$GROUP_ID" ] && chgrp "$GROUP_ID" -R /work

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
 
-# We should be in workdir
-/usr/local/bin/tpaexec "$@"
-res=$?
-[ -n "$USER_ID" ] && chown "$USER_ID" -R .
-[ -n "$GROUP_ID" ] && chgrp "$GROUP_ID" -R .
-exit "$res"
+set -x
+
+reset_perms() {
+    [ -n "$USER_ID" ] && chown "$USER_ID" -R /work
+    [ -n "$GROUP_ID" ] && chgrp "$GROUP_ID" -R /work
+}
+# Ensure the reset is ran if the container is stopped with `docker stop` or `docker kill`
+trap 'reset_perms' SIGTERM
+
+/usr/local/bin/tpaexec "$@" &
+wait $!
+# SIGINT whilst child proc is running is not seen by trap so we run a copy here instead of using
+# trap copy_output SIGINT EXIT
+reset_perms


### PR DESCRIPTION
- Update base image of Debian to bullseye.
- Install whichever generic python3 version. Note TPA is not fully tested with python3.11.
- Remove add-apt-repository as it didn't work and lowers package footprint.
- Install community ansible by default.
- Add an entrypoint script that can reset permissions of files created on exit.