### PR TITLE
Run pg-backup-api tests as root

### DIFF
--- a/roles/test/tasks/pg-backup-api.yml
+++ b/roles/test/tasks/pg-backup-api.yml
@@ -16,6 +16,7 @@
     client_key: /etc/tpa/pg-backup-api/pg-backup-user.key
     return_content: yes
   register: pgbapi_diagnose
+  become: true
 
 - assert:
     msg: >


### PR DESCRIPTION
Add `become: yes` to one of the pg-backup-api test tasks so that it runs as root even when `ansible_user` is another user.

References: TPA-471