### PR TITLE
Avoid attempting to use non-existent 2q repos

### DIFF
--- a/lib/tpaexec/architecture.py
+++ b/lib/tpaexec/architecture.py
@@ -1130,6 +1130,12 @@ class Architecture(object):
             cluster_vars.update({"tpa_2q_repositories": tpa_2q_repositories})
             return
 
+        # If we are configuring for a postgres version at least 16, we
+        # explicitly set tpa_2q_repositories to be empty, so that it
+        # doesn't get any entries automatically added at deploy-time
+        if int(self.args.get("postgres_version")) >= 16:
+            cluster_vars.update({"tpa_2q_repositories": []})
+
         # We know that the cluster doesn't need any 2Q repos, either because the
         # user asked for them explicitly, or because other configure options did
         # so implicitly. Now we can focus on setting edb_repositories correctly.


### PR DESCRIPTION
Explicitly set tpa_2q_repositories to be empty in config.yml if postgres_version >= 16 and no 2q repositories have been explicitly asked for in the invocation of `tpaexec configure`. This suppresses the behaviour we would otherwise get at deploy-time whereby the `dl/default/release` repository would be added; this repository doesn't exist for postgres 16.

References: TPA-577