### PR TITLE
TPA-472: Add repository cleanup to upgrade

### DIFF
--- a/architectures/BDR-Always-ON/commands/upgrade.yml
+++ b/architectures/BDR-Always-ON/commands/upgrade.yml
@@ -76,6 +76,22 @@
 # which we attempt the updates (for example, to make sure that primary
 # instances are updated last in the cycle).
 
+- name: Update repository configuration, if required
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  become_user: root
+  become: yes
+  environment: "{{ target_environment }}"
+  hosts: "{{ update_hosts|default('all') }}"
+  tasks:
+  - name: Configure local-repo, if available
+    include_role:
+      name: sys/local_repo
+
+  - name: Set up repositories
+    include_role:
+      name: sys/repositories
+
 - name: Update postgres on instances in cluster {{ cluster_dir }}
   any_errors_fatal: true
   max_fail_percentage: 0

--- a/architectures/M1/commands/upgrade.yml
+++ b/architectures/M1/commands/upgrade.yml
@@ -5,6 +5,22 @@
 - import_playbook: "{{ tpa_dir }}/architectures/lib/init.yml"
   tags: always
 
+- name: Update repository configuration, if required
+  any_errors_fatal: true
+  max_fail_percentage: 0
+  become_user: root
+  become: yes
+  environment: "{{ target_environment }}"
+  hosts: "{{ update_hosts|default('all') }}"
+  tasks:
+  - name: Configure local-repo, if available
+    include_role:
+      name: sys/local_repo
+
+  - name: Set up repositories
+    include_role:
+      name: sys/repositories
+
 - name: Stop repmgr
   any_errors_fatal: true
   max_fail_percentage: 0


### PR DESCRIPTION
Add repository configuration to upgrade playbooks (BDR-Always-ON, M1) to ensure that repositories are updated before upgrade process, especially for local-repo-only clusters.