### PR TITLE
TPA-554: Fix Cohost harp proxy/manager config

### DIFF
--- a/roles/harp/config/tasks/harp2.yml
+++ b/roles/harp/config/tasks/harp2.yml
@@ -15,10 +15,6 @@
     - role_readonly
     - role_subscriber-only
     - role_witness
-    pgbouncer_bin_dirs:
-      Debian: /usr/sbin
-      RedHat: /usr/bin
-    pgbouncer_bin_dir: "{{ pgbouncer_bin_dirs[ansible_os_family] }}"
   notify: Note HARP bootstrap required
   when:
     initialise_harp|bool
@@ -84,7 +80,30 @@
     and not( harp_http_options['cert_file'] is defined
           or harp_http_options['key_file'] is defined )
 
-- name: Install HARP configuration file
+- name: Record whether HARP proxy and manager are co-hosted
+  set_fact:
+    harp_cohost: "{{ 'bdr' in role and 'harp-proxy' in role }}"
+
+- name: Install HARP-proxy configuration file
+  template:
+    src: harp2.config.j2
+    dest: "{{ harp_directory }}/{{ prefix }}config.yml"
+    owner: "{{ postgres_user }}"
+    group: "{{ postgres_group }}"
+    mode: 0644
+  vars:
+    pgbouncer_bin_dirs:
+      Debian: /usr/sbin
+      RedHat: /usr/bin
+    pgbouncer_bin_dir: "{{ pgbouncer_bin_dirs[ansible_os_family] }}"
+    config_for: 'proxy'
+    prefix: "{{ harp_cohost|ternary('proxy-','') }}"
+  notify: Note HARP restart required
+  when: >
+    initialise_harp|bool
+    and 'harp-proxy' in role
+
+- name: Install HARP manager configuration file
   template:
     src: harp2.config.j2
     dest: "{{ harp_directory }}/config.yml"
@@ -92,18 +111,15 @@
     group: "{{ postgres_group }}"
     mode: 0644
   vars:
-    bdr_ro_groups:
-    - role_replica
-    - role_readonly
-    - role_subscriber-only
-    - role_witness
     pgbouncer_bin_dirs:
       Debian: /usr/sbin
       RedHat: /usr/bin
     pgbouncer_bin_dir: "{{ pgbouncer_bin_dirs[ansible_os_family] }}"
+    config_for: 'manager'
   notify: Note HARP restart required
-  when:
+  when: >
     initialise_harp|bool
+    and 'postgres' in role
 
 # Instances with harp-proxy in role will install pgbouncer (via package
 # dependencies), but harp_proxy will manage the pgbouncer configuration.

--- a/roles/harp/config/templates/harp2.config.j2
+++ b/roles/harp/config/templates/harp2.config.j2
@@ -20,7 +20,7 @@ dcs:
 {%     endif %}
 {%   endfor %}
 {% elif harp_consensus_protocol == 'bdr' %}
-{%   if 'harp-proxy' not in role %}
+{%   if config_for == 'manager' %}
   - "{{ bdr_node_local_dsn }}"
 {%   else %}
 {%     for h in groups[bdr_node_group]|sort %}
@@ -36,7 +36,7 @@ dcs:
 {%   endif %}
 {% endif %}
 
-{% if 'postgres' in role %}
+{% if config_for == 'manager' %}
 manager:
   name: "{{ bdr_node_name|default(inventory_hostname) }}"
   log_level: "{{ harp_log_level|default('info') }}"
@@ -44,7 +44,7 @@ manager:
   stop_command: {{ harp_postgres_stop_command | default('sudo systemctl stop postgres') }}
   status_command: {{ harp_postgres_status_command | default('sudo systemctl status postgres') }}
 {% endif %}
-{% if 'harp-proxy' in role %}
+{% if config_for == 'proxy' %}
 proxy:
   log_level: "{{ harp_log_level|default('info') }}"
   name: "{{ inventory_hostname }}-proxy"

--- a/roles/harp/service/tasks/main.yml
+++ b/roles/harp/service/tasks/main.yml
@@ -9,6 +9,9 @@
 # The harp packages hardcode postgres/postgres, so we must override the
 # default unit definitions if we want to run harp services as another
 # user or group.
+- name: Record whether HARP proxy and manager are co-hosted
+  set_fact:
+    harp_cohost: "{{ 'bdr' in role and 'harp-proxy' in role }}"
 
 - block:
   - name: Ensure harp-manager service directory exists
@@ -26,6 +29,10 @@
       owner: root
       group: root
       mode: 0644
+    vars:
+      config_for: 'manager'
+    notify:
+      - Note HARP restart required
     register: manager_unit
 
   - name: Install harp-postgres.target definition
@@ -67,7 +74,11 @@
       owner: root
       group: root
       mode: 0644
+    vars:
+      config_for: 'proxy'
     register: proxy_unit
+    notify:
+      - Note HARP restart required
   when: >
     'harp-proxy' in role
 

--- a/roles/harp/service/templates/harp.service.j2
+++ b/roles/harp/service/templates/harp.service.j2
@@ -1,5 +1,5 @@
 {# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved. #}
-{% if 'postgres' in role %}
+{% if config_for=='manager' %}
 [Unit]
 PartOf=harp-postgres.target
 After={{ postgres_service_name }}-monitor.service
@@ -8,16 +8,20 @@ After={{ postgres_service_name }}-monitor.service
 [Service]
 {%     if postgres_user != 'postgres' or postgres_group != 'postgres' %}
 User={{ postgres_user }}
-Group={{ postgres_user }}
+Group={{ postgres_group }}
 {%     endif %}
 {%     if harp_manager_restart_on_failure|default(false) %}
 Restart=on-failure
 {%     endif %}
 {%   endif %}
-{% else %}
-{%   if postgres_user != 'postgres' or postgres_group != 'postgres' %}
+{% elif config_for=='proxy' %}
+{%   if postgres_user != 'postgres' or postgres_group != 'postgres' or harp_cohost %}
 [Service]
 User={{ postgres_user }}
-Group={{ postgres_user }}
+Group={{ postgres_group }}
+{%   endif %}
+{%   if harp_cohost %}
+ExecStart=
+ExecStart=/usr/bin/harp-proxy -f "{{ harp_directory }}/proxy-config.yml"
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Ensure that both harp-proxy and harp-manager are correctly configured when both roles are cohosted on a node.

Use a different config file for proxy when cohost is detected. proxy-config.yml is used and service file override is set accordingly.

Fix non detected bug for harp service file override also for cohosted proxy
where override for manager would also be applied to proxy service.

Clean up unused vars set for harp config templating leftover from TPA-72 split of tasks