### PR TITLE
Fix `docker build` of `tpa/ubuntu:jammy` image

### DIFF
--- a/platforms/docker/docker_image.yml
+++ b/platforms/docker/docker_image.yml
@@ -75,7 +75,7 @@
       ubuntu-20.04: ubuntu:focal
       ubuntu-focal: ubuntu:focal
       ubuntu-22.04: ubuntu:jammy
-      ubunty-jammy: ubuntu:jammy
+      ubuntu-jammy: ubuntu:jammy
       ubuntu-latest: ubuntu:jammy
       redhat-7: centos:7
       redhat-8: rockylinux:8


### PR DESCRIPTION
Previous to this commit TPA was failing to execute `tpaexec deploy` or `tpaexec download-packages` for clusters attempting to use the Docker image `tpa/ubuntu:jammy`. The following error was observed:

```
Please specify build instructions for ubuntu:jammy in docker_images
```

The issue was caused because of a typo in the mapping specified inside `platforms/docker/docker_image.yml`.

This commit fixes that issue.

References: TPA-594.