### PR TITLE
Make community ansible the default

### DIFF
--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -237,7 +237,7 @@ _install_ansible_collections() {
 }
 
 setup() {
-    use_community=false
+    use_community=true
     while [[ $# -gt 0 ]]; do
         opt=$1
         shift
@@ -254,6 +254,9 @@ setup() {
             --use-community-ansible)
                 use_community=true
                 ;;
+            --use-2q-ansible)
+                use_community=false
+                ;;
             *)
                 error "unrecognised option: $opt"
                 ;;
@@ -269,19 +272,15 @@ _display_notification() {
     if [[ $use_community == false ]]; then
         cat <<NOTIFICATION
 
-TPA now supports ansible community, you may choose to use it by
-using --use-community-ansible option during setup, default will be to use the
-legacy 2ndQuadrant/ansible fork. This will change in a future release,
-support for 2ndQuadrant/ansible will be dropped and community ansible will
-become the new default.
+You have selected to use the 2ndQuadrant ansible fork. This is now
+deprecated in favour of community ansible and will cease to be supported
+in a future TPA release.
 
-notable difference:
-    - change the --skip-flags options to community behavior where a
-    task will be skipped if part of the list given to the --skip-tag
-    option even if it is also tagged with special tag 'always'.
-    TPA expects all tasks tagged with 'always' to be run to ensure
-    a complete deployment, therefor --skip-tags should not be used when
-    using community ansible.
+If you choose to re-run `tpaexec setup` to use community ansible, please
+be aware that the behaviour of the `--skip-tags` option is different and
+this option is not supported by TPA with community ansible. An alternative
+means of skipping tasks will be provided before support for 2ndQuadrant
+ansible is removed.
 
 NOTIFICATION
 

--- a/docs/src/INSTALL.md
+++ b/docs/src/INSTALL.md
@@ -4,7 +4,7 @@ To use TPA, you need to install from packages or source and run the
 `tpaexec setup` command. This document explains how to install TPA
 packages. If you have an EDB subscription plan, and therefore have
 access to the EDB repositories, you should follow these instructions. To
-install TPA from source, please refer to 
+install TPA from source, please refer to
 [Installing TPA from Source](INSTALL-repo.md).
 
 See [Distribution support](distributions.md) for information
@@ -51,7 +51,7 @@ More detailed explanations of each step are given below.
 ## Where to install TPA
 
 As long as you are using a supported platform, TPA can be installed and
-run from your workstation. This is fine for learning, local testing or 
+run from your workstation. This is fine for learning, local testing or
 demonstration purposes. TPA supports [deploying to Docker containers](platform-docker.md)
 should you wish to perform a complete deployment on your own workstation.
 
@@ -199,16 +199,13 @@ this, but others will not work without it.
 
 ## Ansible community support
 
-TPA now supports ansible community, you may choose to use it by
-using `--use-community-ansible` option during `tpaexec setup`, default
-will be to use the legacy 2ndQuadrant/ansible fork. This will change in
-a future release, support for 2ndQuadrant/ansible will be dropped and
-community ansible will become the new default.
+TPA now uses the community distribution of ansible by default; you can
+continue to use the 2ndQuadrant/ansible fork by passing the
+`--use-2q-ansible` option to `tpaexec setup`. In a future TPA release,
+support for the 2ndQuadrant ansible fork will be removed.
 
-notable difference:
-- change the `--skip-flags` options to community behavior where a
-task will be skipped if part of the list given to the `--skip-tags`
-option even if it is also tagged with special tag `always`.
-TPA expects all tasks tagged with `always` to be run to ensure
-a complete deployment, therefor `--skip-tags` should not be used when
-using community ansible.
+For most users, this makes no difference. However, if you are using
+`--skip-tags` with 2ndQuadrant ansible, be aware that this is not supported
+An alternative means of skipping tasks, compatible with all ansible
+versions, will be provided before support for 2ndQuadrant ansible is
+removed.


### PR DESCRIPTION
When `tpaexec setup` is run, it will now default to community ansible rather than 2ndQuadrant ansible. The new option `--use-2q-ansible` will force the old behaviour and trigger a warning message about the deprecation of 2ndQuadrant ansible.

Fixes: TPA-499