### PR TITLE
Add reconciling local changes doc

### DIFF
--- a/docs/src/reconciling-local-changes.md
+++ b/docs/src/reconciling-local-changes.md
@@ -48,12 +48,13 @@ exist and cause no issues with TPA at all. You may prefer to manage the
 user through TPA in which case you can declare it in `config.yml` but
 the existence of a manually-added user will cause no operational issues.
 
-Some manual additions can have more nuanced effects. Consider manually
-adding an extension. Because TPA does not make destructive changes, the
-extension will not be removed when `tpaexec deploy` is next run.
-**However**, if you made any changes to the Postgres configuration to
-accommodate the new extension these may be overwritten if you did not
-make them using one of TPA's supported mechanisms (see below).
+Some manual additions can have more nuanced effects. Take the example of
+an extension which has been manually added. Because TPA does not make
+destructive changes, the extension will not be removed when `tpaexec
+deploy` is next run. **However**, if you made any changes to the
+Postgres configuration to accommodate the new extension these may be
+overwritten if you did not make them using one of TPA's supported
+mechanisms (see below).
 
 Furthermore, TPA will not make any attempt to modify the `config.yml`
 file to reflect manual changes and the new extension will be omitted

--- a/docs/src/reconciling-local-changes.md
+++ b/docs/src/reconciling-local-changes.md
@@ -42,16 +42,15 @@ and whether the change blocks TPA from running by causing an error or
 invalidating the data in `config.yml`.
 
 ### Non-destructive, non-blocking changes
-Additive changes that can be detected by TPA by inspecting the cluster
-are often accommodated with no operational issues, Consider manually
-adding an extension. Because TPA does not make destructive changes, the
-extension will not be removed when `tpaexec deploy` is next run.
-Furthermore, because TPA inspects the cluster prior to making changes,
-`tpaexec upgrade` will successfully upgrade the new extension despite it
-being absent from `config.yml`.
+Additive changes are often accommodated with no immediate operational
+issues, Consider manually adding an extension. Because TPA does not make
+destructive changes, the extension will not be removed when `tpaexec
+deploy` is next run.
 
-It should be noted however that, even when such a change is detected,
-TPA will not make any attempt to modify the `config.yml` file.
+It should be noted however that, TPA will not make any attempt to modify
+the `config.yml` file to reflect this change and the new extension will
+be omitted from `tpaexec upgrade` which could lead to incompatible
+software versions existing on the cluster.
 
 ### Destructive, non-blocking changes
 Destructive changes that are easily detected and do not block TPA's

--- a/docs/src/reconciling-local-changes.md
+++ b/docs/src/reconciling-local-changes.md
@@ -1,0 +1,82 @@
+# Reconciling changes made outside of TPA
+
+In general, if a cluster was created using TPA it is advisable to manage
+configuration changes to that cluster using TPA. This page is designed
+to help users understand how TPA manages configuration, what the
+implications of making local changes to a TPA-managed cluster are, and
+how to reconcile such changes.
+
+## What constitutes a configuration change?
+*This definition seems questionable with changes which wouldn't normally
+appear in the config at all, like inserting some data into a table*
+Consider a cluster, 'A'. Now imagine a change is applied to it and call
+the resulting cluster 'B'. If the config.yml required to deploy a fresh
+cluster identical to 'A' is different to the config.yml required to
+deploy a cluster identical to 'B' then the change you made is a
+configuration change.
+
+## Are there configuration changes which cannot be performed using TPA?
+Yes, there are changes which would meet the above definition that cannot
+be implemented by TPA. The most notable class of such changes is
+*destructive changes*. In general TPA will not remove previously
+deployed elements of a cluster, even if these are removed from the
+config.yml. This sometimes surprises people because a strictly
+declarative system should always mutate the deployed artifacts to match
+the declaration. However, making destructive change to production
+database can have serious consequences so it is something we have chosen
+not to support.
+
+## What can happen if changes are not reconciled?
+A general issue with unreconciled changes is that if you deploy a new
+cluster using your existing config.yml, or provide your config.yml to
+EDB Support in order to reproduce a problem, it will not match the
+original cluster. In addition, there is potential for operational
+problems should you wish to use TPA to manage that cluster in future.
+
+The operational impact of unreconciled changes varies depending on the
+nature of the changes. In particular whether the change is destructive,
+and whether the change blocks TPA from.
+
+### Non-destructive, non-blocking changes
+Additive changes that can be detected by TPA by inspecting the cluster
+are often accommodated with no operational issues, Consider manually
+adding an extension. Because TPA does not make destructive changes, the
+extension will not be removed when `tpaexec deploy` is next run.
+Furthermore, because TPA inspects the cluster prior to making changes,
+`tpaexec upgrade` will successfully upgrade the new extension despite it
+being absent from the config.yml.
+
+It should be noted however that, even when such a change is detected,
+TPA will not make any attempt to modify the config.yml file.
+
+### Destructive, non-blocking changes
+Destructive changes that are easily detected and do not block TPA's
+operation will simply be undone when `tpaexec deploy` is next run.
+Consider manually removing an extension. From the perspective of TPA,
+this situation is indistinguishable from the user adding an extension to
+the config.yml file and running deploy. As such, TPA will add the
+extension such that the cluster and the config.yml are reconciled, albeit
+in the opposite way to that the user intended.
+
+### Destructive, blocking changes
+Changes which create a more fundamental mismatch between config.yml can
+block TPA from performing operations. For example if you physically
+remove a node in a bare metal cluster, attempts by TPA to connect to
+that node will fail, meaning most TPA operations will exit with an error
+and you will be unable to manage the cluster with TPA until you
+reconcile this difference.
+
+### Non-destructive, blocking changes
+Changes do not have to be destructive to be blocking... 
+changing the superuser password? Or would TPA just change it back using local auth?
+
+## How to reconcile configuration changes
+In general, the reconciliation process involves modifying config.yml
+such that it describes the current state of the cluster and then running
+`tpaexec deploy` to verify that it can run, and ?is there another reason?
+
+### Example: removing a node
+
+### Example: adding an extension
+An M1 cluster 
+

--- a/docs/src/reconciling-local-changes.md
+++ b/docs/src/reconciling-local-changes.md
@@ -43,14 +43,23 @@ invalidating the data in `config.yml`.
 
 ### Non-destructive, non-blocking changes
 Additive changes are often accommodated with no immediate operational
-issues, Consider manually adding an extension. Because TPA does not make
-destructive changes, the extension will not be removed when `tpaexec
-deploy` is next run.
+issues. Consider manually adding a user. The new user will continue to
+exist and cause no issues with TPA at all. You may prefer to manage the
+user through TPA in which case you can declare it in `config.yml` but
+the existence of a manually-added user will cause no operational issues.
 
-It should be noted however that, TPA will not make any attempt to modify
-the `config.yml` file to reflect this change and the new extension will
-be omitted from `tpaexec upgrade` which could lead to incompatible
-software versions existing on the cluster.
+Some manual additions can have more nuanced effects. Consider manually
+adding an extension. Because TPA does not make destructive changes, the
+extension will not be removed when `tpaexec deploy` is next run.
+**However**, if you made any changes to the Postgres configuration to
+accommodate the new extension these may be overwritten if you did not
+make them using one of TPA's supported mechanisms (see below).
+
+Furthermore, TPA will not make any attempt to modify the `config.yml`
+file to reflect manual changes and the new extension will be omitted
+from `tpaexec upgrade` which could lead to incompatible software
+versions existing on the cluster.
+
 
 ### Destructive, non-blocking changes
 Destructive changes that are easily detected and do not block TPA's
@@ -95,7 +104,7 @@ command such as:
 tpaexec configure mycluster \
 -a PGD-Always-ON \
 --platform bare \
---edbpge 15
+--edbpge 15 \
 --location-names a \
 --pgd-proxy-routing local
 ```
@@ -212,7 +221,7 @@ extension in the first place) by adding the following cluster variables.
 ```yaml
 cluster_vars:
   ...  
-  packages:
+  extra_postgres_packages:
    common:
    - postgresql-15-pgvector
   postgres_extensions:
@@ -220,8 +229,8 @@ cluster_vars:
   ```
 
 After adding this configuration, you may manually remove the extension
-by executing the SQL command `DROP EXTENSION vector;` and then `apt
-remove postgresql-15-pgvector`. However if you run `tpaexec deploy`
+by executing the SQL command `DROP EXTENSION vector;` and then 
+`apt remove postgresql-15-pgvector`. However if you run `tpaexec deploy`
 again without reconciling `config.yml`, the extension will be
 reinstalled. To reconcile `config.yml`, simply remove the lines added
 previously.

--- a/docs/src/reconciling-local-changes.md
+++ b/docs/src/reconciling-local-changes.md
@@ -1,10 +1,12 @@
 # Reconciling changes made outside of TPA
+Any changes made to a TPA created cluster that are not performed by
+changing the TPA configuration will not be saved in `config.yml`. This
+means that your cluster will have changes that the TPA configuration
+won't be able to recreate.
 
-In general, if a cluster was created using TPA it is advisable to manage
-configuration changes to that cluster using TPA. This page is designed
-to help users understand how TPA manages configuration, what the
-implications of making local changes to a TPA-managed cluster are, and
-how to reconcile such changes. 
+This page shows how configuration is managed with TPA and the preferred
+ways to make configuration changes. We then look at strategies to make,
+and reconcile, the results of making manual changes to the cluster.
 
 ## Why might I need to make manual configuration changes?
 The most common scenario in which you may need to make configuration
@@ -56,9 +58,9 @@ Destructive changes that are easily detected and do not block TPA's
 operation will simply be undone when `tpaexec deploy` is next run.
 Consider manually removing an extension. From the perspective of TPA,
 this situation is indistinguishable from the user adding an extension to
-the config.yml file and running deploy. As such, TPA will add the
-extension such that the cluster and the config.yml are reconciled, albeit
-in the opposite way to that the user intended.
+the `config.yml` file and running deploy. As such, TPA will add the
+extension such that the cluster and the `config.yml` are reconciled,
+albeit in the opposite way to that the user intended.
 
 Similarly, changes made manually to configuration parameters will be
 undone unless they are:
@@ -74,8 +76,8 @@ there is no pressing operational reason to reconcile changes made by
 method 1 or 2.
 
 ### Destructive, blocking changes
-Changes which create a more fundamental mismatch between config.yml can
-block TPA from performing operations. For example if you physically
+Changes which create a more fundamental mismatch between `config.yml`
+can block TPA from performing operations. For example if you physically
 remove a node in a bare metal cluster, attempts by TPA to connect to
 that node will fail, meaning most TPA operations will exit with an error
 and you will be unable to manage the cluster with TPA until you
@@ -166,14 +168,17 @@ directory has been deleted.
 TPA automatically generates a password for the superuser which you may
 view using `tpaexec show-password <cluster> <superuser-name>`. If you
 change the password manually (for example using the `/password` command
-in psql) you will find that on after `tpaexec deploy` is next run, the
+in psql) you will find that after `tpaexec deploy` is next run, the
 password has reverted to the one set by TPA. To make the change through
 TPA, and therefore make it persist across runs of `tpaexec deploy`, you
 must use the command `tpaexec store-password <cluster> <superuser-name>`
-to specify the password, then run `tpaexec deploy`.
+to specify the password, then run `tpaexec deploy`. This also applies to
+any other user created through TPA.
 
 ### Example: adding or removing an extension
-A simple single-node cluster can be deployed with the following config.yml. 
+A simple single-node cluster can be deployed with the following
+`config.yml`.
+
 ```yaml
 ---
 architecture: M1
@@ -200,9 +205,9 @@ instances:
 You may manually add the pgvector extension by connecting to the node
 and running `apt install postgresql-15-pgvector` then executing the
 following SQL command: `CREATE EXTENSION vector;`. This will not cause
-any operational issues, beyond the fact that config.yml no longer
+any operational issues, beyond the fact that `config.yml` no longer
 describes the cluster as fully as it did previously. However, it is
-advisable to reconcile config.yml (or indeed simply use TPA to add the
+advisable to reconcile `config.yml` (or indeed simply use TPA to add the
 extension in the first place) by adding the following cluster variables. 
 
 ```yaml
@@ -218,13 +223,13 @@ cluster_vars:
 After adding this configuration, you may manually remove the extension
 by executing the SQL command `DROP EXTENSION vector;` and then `apt
 remove postgresql-15-pgvector`. However if you run `tpaexec deploy`
-again without reconciling the config.yml, the extension will be
-reinstalled. To reconcile the config.yml, simply remove the lines added
+again without reconciling `config.yml`, the extension will be
+reinstalled. To reconcile `config.yml`, simply remove the lines added
 previously.
 
 !!! Note 
 As noted previously, TPA will not honour destructive changes.
-So simply removing the lines from config.yml will not remove the
+So simply removing the lines from `config.yml` will not remove the
 extension. It is necessary to perform this operation manually then
 reconcile the change.
 !!!


### PR DESCRIPTION
Add a page that describes the consequences of making local changes to a TPA-managed cluster and how one might recover from such a situation. This is not intended to be exhaustive, but to go some way to filling the void of documentation around such situations.