### PR TITLE
TPA-462: create symlink to cli default config path

### DIFF
--- a/roles/pgdcli/config/tasks/main.yml
+++ b/roles/pgdcli/config/tasks/main.yml
@@ -28,3 +28,12 @@
     owner: "{{ pgd_cli_user }}"
     group: "{{ pgd_cli_group }}"
     mode: 0600
+# Add a symlink to the default path for pgdcli config.
+# For pgdcli V1, this allows using cli without having to supply path to
+# config file via `-f`.
+
+- name: Create symlink to ease cli usage
+  file:
+    state: link
+    src: "{{ pgdcli_directory }}/pgd-cli-config.yml"
+    dest: /etc/edb/pgd-config.yml


### PR DESCRIPTION
Add a symlink to the default path for pgdcli config.
This allows use of pgdcli without adding `-f` switch for pgdcli v1.

