### PR TITLE
bin/tpaexec: using single quotes in the notification.

### DIFF
--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -276,8 +276,8 @@ You have selected to use the 2ndQuadrant ansible fork. This is now
 deprecated in favour of community ansible and will cease to be supported
 in a future TPA release.
 
-If you choose to re-run `tpaexec setup` to use community ansible, please
-be aware that the behaviour of the `--skip-tags` option is different and
+If you choose to re-run 'tpaexec setup' to use community ansible, please
+be aware that the behaviour of the '--skip-tags' option is different and
 this option is not supported by TPA with community ansible. An alternative
 means of skipping tasks will be provided before support for 2ndQuadrant
 ansible is removed.


### PR DESCRIPTION
Without this, bash is handling some of the words in the heredoc as commands. Replacing the backtick by single quotes to keep the same format along the file.

[root@d0afd2ae4168 /]# /opt/EDB/TPA/bin/tpaexec setup --use-2q-ansible /opt/EDB/TPA/bin/tpaexec: line 273: tpaexec: command not found /opt/EDB/TPA/bin/tpaexec: line 273: --skip-tags: command not found