### PR TITLE
Enhanced SLES 15 support; move to SLES 15sp5

### DIFF
--- a/lib/tpaexec/architecture.py
+++ b/lib/tpaexec/architecture.py
@@ -1124,7 +1124,7 @@ class Architecture(object):
         # BDR.update_cluster_vars), and we don't need to do anything more (and
         # we must not configure any edb_repositories).
 
-        if "tpa_2q_repositories" in cluster_vars:
+        if cluster_vars.get("tpa_2q_repositories"):
             return
 
         # Otherwise, if --2Q-repositories is specified, we use the repository

--- a/lib/tpaexec/platforms/aws.py
+++ b/lib/tpaexec/platforms/aws.py
@@ -156,12 +156,13 @@ class aws(CloudPlatform):
                 },
             },
             "sles": {
-                "suse-sles-15-sp4-v20230428-hvm-ssd-x86_64": {
+                "suse-sles-15-sp5-v20231020-hvm-ssd-x86_64": {
                     "versions": ["15"],
                     "preferred_python_version": "python3",
                     "owner": "013907871322",
                     "user": "ec2-user",
                 }
+
             },
         }
 

--- a/platforms/docker/docker_image.yml
+++ b/platforms/docker/docker_image.yml
@@ -89,7 +89,7 @@
       almalinux-8: almalinux:8
       almalinux-9: almalinux:9
       almalinux-latest: almalinux:9
-      sles-15: registry.suse.com/bci/bci-base:15.4
+      sles-15: registry.suse.com/bci/bci-base:15.5
   when:
     image.startswith('tpa/')
     and _image_key in _tpa_images

--- a/roles/efm/pkg/defaults/main.yml
+++ b/roles/efm/pkg/defaults/main.yml
@@ -7,4 +7,6 @@ efm_packages:
     - "edb-efm{{ efm_versionNN }}"
   RedHat:
     - "edb-efm{{ efm_versionNN }}"
+  SUSE:
+    - "edb-efm{{ efm_versionNN }}"
   Ubuntu: *debian_efm_packages

--- a/roles/sys/repositories/tasks/os/SUSE/repositories.yml
+++ b/roles/sys/repositories/tasks/os/SUSE/repositories.yml
@@ -14,25 +14,8 @@
     that: item in default_suse_repositories|combine(suse_repositories)
   with_items: "{{ suse_repository_list }}"
 
-# all repositories must have a "repo" field
-
-#- name: Install SUSE repositories
-#  zypper_repository:
-#    description: "{{ repo.description|default(omit) }}"
-#    repo: "{{ repo.repo_uri }}"
-#    auto_import_keys: "true"
-#      #autorefresh: "true"
-#      #runrefresh: "true"
-#  with_items: "{{ suse_repository_list }}"
-#  loop_control:
-#    loop_var: r
-#  vars:
-#    repos: "{{ default_suse_repositories|combine(suse_repositories) }}"
-#    repo_name: "{{ r }}"
-#    repo: "{{ repos[r] }}"
-
 - name: Install SUSE repositories
-  shell: zypper --non-interactive addrepo --refresh --priority 50 --check {{ repo.repo_uri }}; zypper --gpg-auto-import-keys refresh
+  shell: zypper --non-interactive addrepo --refresh --priority 75 --check {{ repo.repo_uri }}; zypper --gpg-auto-import-keys refresh
   with_items: "{{ suse_repository_list }}"
   loop_control:
     loop_var: r
@@ -68,6 +51,7 @@
     repo: "{{ repo.uri }}"
     runrefresh: true
     auto_import_keys: true
+    priority: 50
   with_items: "{{ edb_repositories}} "
   loop_control:
     loop_var: repository
@@ -82,6 +66,7 @@
     repo: "{{ repo.uri }}"
     runrefresh: true
     auto_import_keys: true
+    priority: 50
   with_items: "{{ edb_repositories}} "
   loop_control:
     loop_var: repository

--- a/roles/sys/sysctl/tasks/os/SUSE.yml
+++ b/roles/sys/sysctl/tasks/os/SUSE.yml
@@ -1,0 +1,35 @@
+---
+
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+# Add hugepages=N and transparent_hugepage=never to GRUB_CMDLINE_LINUX
+# in /etc/default/grub and run update-grub.
+#
+# Because it's fiddly to try to add to GRUB_CMDLINE_LINUX in place, and
+# because /etc/default/grub is documented to be a shell script that is
+# source'd, we can just add an extra line to it.
+
+- name: Set kernel commandline in /etc/default/grub
+  shell: >
+    source /etc/default/grub;
+    if ! [[ "$GRUB_CMDLINE_LINUX" =~ 'transparent_hugepage=' && "$GRUB_CMDLINE_LINUX" =~ 'hugepage=' ]];
+    then echo 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX hugepages={{ nr_hugepages }} transparent_hugepage={{ transparent_hugepage }}"' >> /etc/default/grub;
+    else echo unchanged;
+    fi
+  args:
+    executable: /bin/bash
+  register: cmdline
+  changed_when: cmdline.stdout != 'unchanged'
+  vars:
+    sysctls: "{{ sysctl_defaults|combine(sysctl_values) }}"
+    nr_hugepages: "{{ sysctls['vm.nr_hugepages'] }}"
+  when:
+    platform not in ['docker', 'lxd']
+    and target_container_type is not defined
+
+- name: Run grub2-mkconfig
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when:
+    cmdline is changed
+    and platform not in ['docker', 'lxd']
+    and target_container_type is not defined


### PR DESCRIPTION
Use sp5 aws ami and docker image when SLES 15 is requested.

Fix repository priorities for SLES so that EDB repositories have priority over PGDG ones, which have priority over vendor ones. Add sp5 aws ami; change default sles 15 docker image to sp5; fix repository priorities so that edb repos have priority over PGDG, which have priority over SUSE-provided repos.

Change configure-time repository selection logic so that EDB repositories can be used on systems such as SLES 15 that don't support 2q repositories, without always having to specify them on the command line.

Support installing EFM on SLES.

Fixes: TPA-604