### PR TITLE
Add python-certifi to requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,13 @@ cryptography
 python-dateutil
 netaddr
 boto3>=1.5.31
+# certifi is an indirect dependency coming from
+# docker -> requests -> certifi and by default
+# it pulls a pretty old version. So adding it
+# here explicitly so we pull the latest always.
+# We can safely remove it after we upgrade to
+# Python >=3.9 as part of edb-python package.
+certifi>=2023.7.22
 docker
 passlib
 psutil


### PR DESCRIPTION
python-certifi is an indirect dependency coming from docker -> requests
-> certifi and by default the version we are getting is pretty old.
Added certifi explicitly to requirements.in so we always pull the latest
compatible version. We can remove it later after we upgrade our basic
python version compatibilty from Python 3.6 (needed for compatibility
with older platforms like RHEL7) to something more recent.

Signed-off-by: Muhammad Haroon <muhammad.haroon@enterprisedb.com>
