### PR TITLE
TPA-614: Fix camo upgrade for 3 to 5 upgrade

### DIFF
--- a/architectures/PGD-Always-ON/upgrade_major_3to5.yml
+++ b/architectures/PGD-Always-ON/upgrade_major_3to5.yml
@@ -242,6 +242,8 @@
         upgrade_from: 3
     - include_role: name=postgres/user
     - include_role: name=postgres/config
+      vars:
+        bdr_version_num: "{{target_bdr_version_num|default(50300)}}"
     - include_role: name=postgres/final
     when: >
       'postgres' in role

--- a/docs/src/tpaexec-upgrade.md
+++ b/docs/src/tpaexec-upgrade.md
@@ -201,6 +201,12 @@ apt only understands `xyz*` (as in the example above).
 Note: see limitations of using wildcards in package_version in
 [tpaexec-configure](tpaexec-configure.md#known-issue-with-wildcard-use).
 
+Note: when upgrading from BDR3.7 to PGD5 using a specific PGD5 version
+you should also specify `-e target_bdr_version_num=5YYZZ`
+with YY the minor version, ZZ the fix version, accordingly to targeted
+`bdr_package_version` already defined. The default is set to `50300`
+which corresponds to PGD version 5.3.
+
 It is your responsibility to ensure that the combination of Postgres,
 PGD, and pglogical package versions that you request are sensible. That
 is, they should work together, and there should be an upgrade path from


### PR DESCRIPTION
During 3to5 upgrade we run postgres/config role to update configuration files for postgres and bdr including camo.
at this point the node is already running PGD5 but it's cluster_vars haven't yet been updated, template for camo config make use of bdr_version_num and this is part of cluster_vars. we need to set manual value for bdr_version_num since running postgres/facts would require starting postgres withou wrong config, it won't work due to pglogical being missing.

we set bdr_version_num to 503000 which is the minimum required to upgrade from bdr3 to pgd5.

see TPA-614 for error message.

Somehting similar could happen to 4to5 upgrade later if a new config for PGD5.3+ appears.