### PR TITLE
Install needed repositories to enable EPAS on SLES

### DIFF
--- a/roles/sys/repositories/tasks/os/SUSE/repositories.yml
+++ b/roles/sys/repositories/tasks/os/SUSE/repositories.yml
@@ -87,7 +87,9 @@
       cmd: SUSEConnect --status-text
     register: registration_status
 
-  - block:
+  - when: >
+      "Not Registered" in registration_status.stdout
+    block:
     - name: Check registration code is available
       assert:
         that: lookup('env', 'SLES_REG_TOKEN') != ""
@@ -97,8 +99,6 @@
       command:
         cmd: SUSEConnect -r {{ lookup('env', 'SLES_REG_TOKEN') }}
 
-    when: >
-      "Not Registered" in registration_status.stdout
 
   - name: Install extra repositories from PackageHub
     command:

--- a/roles/sys/repositories/tasks/os/SUSE/repositories.yml
+++ b/roles/sys/repositories/tasks/os/SUSE/repositories.yml
@@ -74,3 +74,34 @@
     repo:
       uri: https://downloads.enterprisedb.com/{{ edb_repos_token }}/{{ repository }}/rpm/sles/{{ ansible_distribution_major_version }}/noarch/
       name: enterprisedb-{{ repository }}-noarch
+
+- block:
+  - name: Install SUSEConnect
+    zypper:
+      name: SUSEConnect
+      state: present
+
+  - name: Check registration status
+    command:
+      cmd: SUSEConnect --status-text
+    register: registration_status
+
+  - block:
+    - name: Check registration code is available
+      assert:
+        that: lookup('env', 'SLES_REG_TOKEN') != ""
+        msg: "A SLES registration code is required to use EPAS on this system"
+
+    - name: Register system with SUSEConnect
+      command:
+        cmd: SUSEConnect -r {{ lookup('env', 'SLES_REG_TOKEN') }}
+
+    when: >
+      "Not Registered" in registration_status.stdout
+
+  - name: Install extra repositories from PackageHub
+    command:
+      cmd: SUSEConnect -p PackageHub/15.5/x86_64
+
+  when:
+    - postgres_flavour == 'epas'

--- a/roles/sys/repositories/tasks/os/SUSE/repositories.yml
+++ b/roles/sys/repositories/tasks/os/SUSE/repositories.yml
@@ -75,7 +75,8 @@
       uri: https://downloads.enterprisedb.com/{{ edb_repos_token }}/{{ repository }}/rpm/sles/{{ ansible_distribution_major_version }}/noarch/
       name: enterprisedb-{{ repository }}-noarch
 
-- block:
+- when: postgres_flavour == 'epas'
+  block:
   - name: Install SUSEConnect
     zypper:
       name: SUSEConnect
@@ -102,6 +103,6 @@
   - name: Install extra repositories from PackageHub
     command:
       cmd: SUSEConnect -p PackageHub/15.5/x86_64
+    when:
+      not 'PackageHub/15.5/x86_64' in registration_status.stdout
 
-  when:
-    - postgres_flavour == 'epas'


### PR DESCRIPTION
For EPAS on SLES, we need packages that are only available through SLES's PackageHub repositories, which require the system to be registered. We check if this is a registered system, and if isn't, look in the environment for a registration token and use it to register the system.