### PR TITLE
Suppress automatic provision for some deploy options

### DIFF
--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -373,7 +373,10 @@ playbook() {
 }
 
 deploy() {
-    provision
+    NO_PROVISION_OPTIONS="(--help)|(--list-hosts)|(--list-tasks)|(--list-tags)"
+    if [[ ! $@ =~ $NO_PROVISION_OPTIONS ]] ; then
+        provision
+    fi
     playbook deploy.yml "$@"
 }
 


### PR DESCRIPTION
When options that will suppress the actual deployment run are given to `tpaexec deploy`, don't automatically run provision beforehand.

Fixes: TPA-558