### PR TITLE
TPA-592: fix fence/unfence/get node to use bdr_node_name

### DIFF
--- a/roles/postgres/bdr/tasks/fence.yml
+++ b/roles/postgres/bdr/tasks/fence.yml
@@ -25,7 +25,7 @@
   block:
   - name: Run 'harpctl fence'
     command:
-      harpctl -f /etc/harp/config.yml fence --force
+      harpctl -f /etc/harp/config.yml fence {{ bdr_node_name|default(inventory_hostname) }} --force
     become_user: "{{ postgres_user }}"
     become: yes
 
@@ -40,7 +40,7 @@
   - name: Wait for node to be fenced
     command: >
       harpctl -f /etc/harp/config.yml
-      get node {{ inventory_hostname }} -o json
+      get node {{ bdr_node_name|default(inventory_hostname) }} -o json
     register: harpctl_get_node
     become_user: "{{ postgres_user }}"
     become: yes

--- a/roles/postgres/bdr/tasks/unfence.yml
+++ b/roles/postgres/bdr/tasks/unfence.yml
@@ -21,7 +21,7 @@
   block:
   - name: Run 'harpctl unfence'
     command:
-      harpctl -f /etc/harp/config.yml unfence
+      harpctl -f /etc/harp/config.yml unfence {{ bdr_node_name|default(inventory_hostname) }}
     become_user: "{{ postgres_user }}"
     become: yes
 
@@ -40,7 +40,7 @@
   - name: Wait for node to be unfenced
     command: >
       harpctl -f /etc/harp/config.yml
-      get node {{ inventory_hostname }} -o json
+      get node {{ bdr_node_name|default(inventory_hostname) }} -o json
     register: harpctl_get_node
     become_user: "{{ postgres_user }}"
     become: yes


### PR DESCRIPTION
Use the bdr_node_name instead of inventory_hostname. 

Specify node_name for fence and unfence commands to avoid failure and ensure bdr_node_name is used even if this should be the default used via config file.
