### PR TITLE
Enable clustername-prefixed hostnames

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -2,6 +2,18 @@
 
 © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
 
+## v23.26 (unreleased)
+
+### Notable changes
+### Minor changes
+
+- Add --cluster-prefixed-hostnames option to `tpaexec configure`
+
+  This makes it easy to avoid hostname clashes on machines hosting more
+  than one docker cluster.
+
+### Bugfixes
+
 ## v23.25 (2023-11-14)
 
 ### Notable changes

--- a/docs/src/tpaexec-configure.md
+++ b/docs/src/tpaexec-configure.md
@@ -178,6 +178,10 @@ Use `--hostnames-unsorted` to not sort hostnames at all. In this case,
 they will be assigned in the order they are found in the hostnames file.
 This is the default when a hostnames file is explicitly specified.
 
+Use `--cluster-prefixed-hostnames` to make each hostname begin with the
+name of the cluster. This can be useful to avoid hostname clashes when
+running more than one docker cluster on the same host.
+
 Hostnames may contain only letters (a-z), digits (0-9), and '-'. They
 may be FQDNs, depending on the selected platform. Hostnames should be
 in lowercase; any uppercase characters will be converted to lowercase

--- a/lib/tpaexec/architecture.py
+++ b/lib/tpaexec/architecture.py
@@ -383,6 +383,7 @@ class Architecture(object):
         g.add_argument("--hostnames-pattern", metavar="PATTERN")
         g.add_argument("--hostnames-sorted-by", metavar="OPTION")
         g.add_argument("--hostnames-unsorted", action="store_true")
+        g.add_argument("--cluster-prefixed-hostnames", action="store_true")
 
         g = p.add_argument_group("locations")
         g.add_argument("--location-names", metavar="LOCATION", nargs="+")
@@ -585,6 +586,10 @@ class Architecture(object):
         # The architecture's num_instances() method should work by this point,
         # so that we can generate the correct number of hostnames.
         (args["hostnames"], args["ip_addresses"]) = self.hostnames(self.num_instances())
+        if args.get("cluster_prefixed_hostnames"):
+            args["hostnames"] = [
+                args["cluster_name"] + "-" + hostname for hostname in args["hostnames"]
+            ]
 
         # Figure out how to get the desired distribution.
         args["image"] = self.image()

--- a/lib/tpaexec/architectures/bdr.py
+++ b/lib/tpaexec/architectures/bdr.py
@@ -285,10 +285,15 @@ class BDR(Architecture):
                     instance["role"].append("pem-agent")
 
             n = instances[-1].get("node")
+            pemserver_name = (
+                "%s-pemserver" % self.args["cluster_name"]
+                if self.args.get("cluster_prefixed_hostnames")
+                else "pemserver"
+            )
             instances.append(
                 {
                     "node": n + 1,
-                    "Name": "pemserver",
+                    "Name": pemserver_name,
                     "role": ["pem-server"],
                     "location": self.args["locations"][0]["Name"],
                 }

--- a/lib/tpaexec/architectures/m1.py
+++ b/lib/tpaexec/architectures/m1.py
@@ -124,10 +124,16 @@ class M1(Architecture):
                 if "barman" in role and self.args.get("enable_pg_backup_api", False):
                     instance["role"].append("pem-agent")
             n = instances[-1].get("node")
+            pemserver_name = (
+                "%s-pemserver" % self.args["cluster_name"]
+                if self.args.get("cluster_prefixed_hostnames")
+                else "pemserver"
+            )
+
             instances.append(
                 {
                     "node": n + 1,
-                    "Name": "pemserver",
+                    "Name": pemserver_name,
                     "role": ["pem-server"],
                     "location": self.args["locations"][0]["Name"],
                 }


### PR DESCRIPTION
Add an option "--cluster-prefixed-hostnames" to "tpaexec configure", which causes all hostnames to have the cluster name prepended. This avoids hostname clashes when deploying more than one docker cluster simultaneously on the same host.