### PR TITLE
Introducing `postgres_log_file` option. TPA-157

### DIFF
--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -89,6 +89,9 @@ default_postgres_lib_dir:
     RedHat: "/usr/edb/pge{{ postgres_version }}/lib"
     SUSE: "/usr/edb/pge{{ postgres_version }}/lib"
 
+
+default_postgres_log_file: "/var/log/postgres/postgres.log"
+
 default_postgres_tablespaces: {}
 
 default_postgres_extensions:

--- a/roles/init/tasks/postgres.yml
+++ b/roles/init/tasks/postgres.yml
@@ -162,6 +162,7 @@
     postgres_databases: "{{ postgres_databases|default(default_postgres_databases) }}"
     postgres_conf_files: "{{ postgres_conf_files|default(default_postgres_conf_files) }}"
     postgres_hba_local_auth_method: "{{ postgres_hba_local_auth_method|default(default_postgres_hba_local_auth_method) }}"
+    postgres_log_file: "{{ postgres_log_file | default(default_postgres_log_file) }}"
     log_destination: "{{ log_destination|default(default_log_destination) }}"
     install_from_source: "{{ install_from_source|default([]) }}"
     barman_user: "{{ barman_user|default(default_barman_user) }}"

--- a/roles/postgres/config/tasks/set_tpa_facts.yml
+++ b/roles/postgres/config/tasks/set_tpa_facts.yml
@@ -103,8 +103,8 @@
   vars:
     object_varname: postgres_config
     object_contents:
-      log_directory: '/var/log/postgresql'
-      log_filename: 'postgres.log'
+      log_directory: '{{ postgres_log_file | dirname }}'
+      log_filename: '{{ postgres_log_file | basename }}'
       log_file_mode: '0640'
       log_rotation_age: '0'
       log_rotation_size: '0'

--- a/roles/postgres/config/tasks/syslog.yml
+++ b/roles/postgres/config/tasks/syslog.yml
@@ -2,29 +2,33 @@
 
 # © Copyright EnterpriseDB UK Limited 2015-2024 - All rights reserved.
 
-- name: Check the current owner of the postgres log under /var/log/postgres
+- name: Check the current owner of the postgres log {{ postgres_log_file }}
   stat:
-    path: /var/log/postgres/postgres.log
-  register: postgres_log_file
+    path: "{{ postgres_log_file }}"
+  register: log_file
 
-- name: Ensure all log files under /var/log/postgresql are owned by the postgres user and group
+- name: Ensure all log files under {{ log_dir }} are owned by the postgres user and group
   file:
-    path: /var/log/postgres
+    path: "{{ log_dir }}"
     state: directory
     owner: "{{ postgres_user }}"
     group: "{{ postgres_group }}"
     recurse: yes
+  vars:
+    log_dir: "{{ postgres_log_file | dirname }}"
   when:
-    - postgres_log_file.stat.exists
-    - postgres_log_file.stat.pw_name != postgres_user
-    - postgres_log_file.stat.gr_name != postgres_group
+    - log_file.stat.exists
+    - log_file.stat.pw_name != postgres_user
+    - log_file.stat.gr_name != postgres_group
 
 # Even if a stricter default umask is set, we want the permissions on the directory to always be 0700
-- name: Explicitly set permissions for /var/log/postgres to 0700
+- name: Explicitly set permissions for {{ log_dir }} to 0700
   file:
-    path: /var/log/postgres
+    path: "{{ log_dir }}"
     state: directory
     mode: "700"
+  vars:
+    log_dir: "{{ postgres_log_file | dirname }}"
 
 - name: Add rsyslog rule for PostgreSQL logging
   template:

--- a/roles/postgres/config/templates/syslog-postgres.conf.j2
+++ b/roles/postgres/config/templates/syslog-postgres.conf.j2
@@ -7,7 +7,7 @@ if $programname == 'postgres' then {
         FileOwner="{{ postgres_user }}"
         FileGroup="{{ postgres_group }}"
         FileCreateMode="0640"
-        File="/var/log/postgres/postgres.log"
+        File="{{ postgres_log_file }}"
     )
 {% if log_server is not defined %}
     stop

--- a/roles/postgres/config/templates/tpa.conf.j2
+++ b/roles/postgres/config/templates/tpa.conf.j2
@@ -22,8 +22,8 @@ syslog_facility = {{ syslog_facility|default('LOCAL6') }}
 syslog_ident = {{ syslog_ident|default('postgres') }}
 
 {% if log_destination == 'stderr' %}
-log_directory = '/var/log/postgresql'
-log_filename = 'postgres.log'
+log_directory = '{{ postgres_log_file | dirname }}'
+log_filename = '{{ postgres_log_file | basename }}'
 log_file_mode = 0640
 log_rotation_age = 0
 log_rotation_size = 0

--- a/roles/sys/logrotate/tasks/postgres.yml
+++ b/roles/sys/logrotate/tasks/postgres.yml
@@ -11,8 +11,9 @@
     group: root
     mode: "0644"
   vars:
-    postgres_logfile: "{{
+    logrotate_postgres: >-
+      {{
         (log_destination == 'syslog')|ternary(
-          '/var/log/postgres/postgres.log', '/var/log/postgresql/postgres.log'
+          postgres_log_file, '/var/log/postgresql/postgres.log'
         )
-      }}"
+      }}

--- a/roles/sys/logrotate/templates/postgres.j2
+++ b/roles/sys/logrotate/templates/postgres.j2
@@ -1,4 +1,4 @@
-{{ postgres_logfile }} {
+{{ logrotate_postgres }} {
     daily
     maxsize {{ logrotate_maxsize|default('1G') }}
     rotate {{ logrotate_rotate|default('7') }}


### PR DESCRIPTION
This allows TPA to add that option into config.yml for new clusters but also, to set the default in just one place.

Because we're defining the default as '/var/log/postgres/postgres.log', existing clusters don't need to be changed or reconfigured again.