### PR TITLE
TPA-614: Fix camo enabled cluster upgrade from BDR3 to PGD5

### DIFF
--- a/architectures/PGD-Always-ON/upgrade_major_3to5.yml
+++ b/architectures/PGD-Always-ON/upgrade_major_3to5.yml
@@ -241,6 +241,11 @@
       vars:
         upgrade_from: 3
     - include_role: name=postgres/user
+    - include_role:
+        name: postgres/update
+        tasks_from: preconfig.yml
+      vars:
+        upgrade_from: 3
     - include_role: name=postgres/config
     - include_role: name=postgres/final
     when: >

--- a/library/minimal_postgres_setup
+++ b/library/minimal_postgres_setup
@@ -2,7 +2,7 @@
 # © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
 
 source "$1"
-
+postgres_bin_dir=${postgres_bin_dir:-""}
 pgdata=${pgdata:-/opt/postgres/data}
 pgdata_initialised=false
 postgres_running=false
@@ -35,6 +35,12 @@ for F in /etc/edb/pgd-config.yml /etc/edb/pgd-cli/pgd-cli-config.yml /etc/edb/pg
     fi
 done
 
+if command -v "$postgres_bin_dir"/bdr_config; then
+    output=$("$postgres_bin_dir"/bdr_config --version)
+    bdr_major_version=$(sed -En "s/BDR_VERSION_COMPLETE=([^\.]*).*/\1/p" <(echo "${output}"))
+    bdr_version_num=$(sed -En "s/BDR_VERSION_NUM=(.*)/\1/p" <(echo "${output}"))
+fi
+
 grep -Ev '": "*,*$' <<RESULT
 {
     "changed": false,
@@ -47,6 +53,8 @@ grep -Ev '": "*,*$' <<RESULT
         "harp_consensus_protocol": "$harp_consensus_protocol",
         "harp_cluster_name": "$harp_cluster_name",
         "pgd_cluster_name": "$pgd_cluster_name",
+        "bdr_major_version": $bdr_major_version,
+        "bdr_version_num": $bdr_version_num,
         "pgdata": "$pgdata"
     }
 }

--- a/roles/postgres/update/tasks/preconfig.yml
+++ b/roles/postgres/update/tasks/preconfig.yml
@@ -1,0 +1,29 @@
+---
+
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+# we need to run minimal_postgres_setup module to ensure we use
+# the updated values for bdr_version_num and "bdr_major_version":
+# during the postgres/config role.
+
+  - name: Update bdr_version facts
+    when: >
+      'bdr' in role
+    block:
+
+    - name: Run minimal_postgres_setup
+      minimal_postgres_setup:
+        pgdata: "{{ postgres_data_dir|default(default_postgres_data_dir) }}"
+        postgres_bin_dir: "{{ postgres_bin_dir }}"
+      become_user: root
+      become: yes
+
+    - name: Set updated versions
+      action: set_fact
+      args: >
+        {{
+          ('{"bdr_version_num": %s, "bdr_major_version": %s}' % (
+            ansible_facts.bdr_version_num,
+            ansible_facts.bdr_major_version,
+          ))|from_json
+        }}


### PR DESCRIPTION
Fix camo config issue during upgrade from bdr3 to pgd5 using
minimal_postgres_setup module and bdr_config command.

The fix is to update bdr_version facts via minimal_postgres_setup module
before running postgres/config role. it will ensure the correct config
options are set in postgres conf.d/*-camo.conf
Add feature in the minimal_postgres_setup to run bdr_config command and
extract bdr_version_num, bdr_major_version from its output.

This fix should also be used for 4to5 even if there is no breaking conf
set in this case for now.