### PR TITLE
TPA-441: Enable Cgroups v2 Docker environments

### DIFF
--- a/platforms/docker/validate.yml
+++ b/platforms/docker/validate.yml
@@ -16,21 +16,6 @@
   vars:
     _docker_version: "{{ docker_system.host_info.ServerVersion }}"
 
-# Support for CgroupVersion 2 is not fully baked yet for docker sdk in
-# ansible and related tooling so while we try to make sure we are using
-# a recent version of docker; we rely on CgroupVersion 1 until version
-# 2 is fully supported.
-
-- name: Check required docker environment
-  assert:
-    that:
-      - _cgroup_version == '1'
-    msg:
-      - "TPA currently supports CgroupVersion 1 (you are running CgroupVersion {{ _cgroup_version }})"
-      - "Consult platform-docker.md for information on using docker platform"
-  vars:
-    _cgroup_version: "{{ docker_system.host_info.CgroupVersion|default(None) }}"
-
 - name: Ensure that every instance has a defined image
   assert:
     msg: "Please set 'image' on every instance"


### PR DESCRIPTION
Ansible added support for Cgroups v2 in version [ansible-core version 2.14.2 (released on 2023-01-30)](https://github.com/ansible/ansible/blob/v2.14.2/changelogs/CHANGELOG-v2.14.rst#v2142).
Remove the validation step that enforces Cgroups version 1.

Fixes: [TPA-441](https://enterprisedb.atlassian.net/browse/TPA-441)

[TPA-441]: https://enterprisedb.atlassian.net/browse/TPA-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ