### PR TITLE
TPA-628: default camo scope at configure 

### DIFF
--- a/lib/tpaexec/architectures/pgd_always_on.py
+++ b/lib/tpaexec/architectures/pgd_always_on.py
@@ -310,7 +310,7 @@ class PGD_Always_ON(BDR):
                             {
                                 "name": scope,
                                 "origin": group,
-                                "rule": f"ALL ({group}) ON durable CAMO DEGRADE ON (timeout = 3600s) TO ASYNC",
+                                "rule": f"ALL ({group}) ON durable CAMO DEGRADE ON (timeout = 60s,  require_write_lead = true) TO ASYNC",
                             }
                         )
 


### PR DESCRIPTION
Improve configure time default camo rule for pgd5 by adding 
`require_write_lead = true` and setting timeout to `60s`

partially resolves TPA-626