### PR TITLE
TPA-626: upgrade commit scope generation improvements

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -16,6 +16,15 @@
   version, if applicable. `tpaexec deploy` will then apply these changes
   to the servers in the cluster.
 
+### Minor changes
+
+- TPA-626 Improve CAMO commit_scope generation during reconfigure
+
+  Ensure that commit_scope for CAMO enabled partners is generated using
+  existing config options from older BDR versions when running tpaexec
+  reconfigure command to prepare for major PGD upgrade. Improve default
+  value when no previous config exist.
+
 ## v23.26 (2023-11-30)
 
 ### Minor changes

--- a/lib/tpa/instance.py
+++ b/lib/tpa/instance.py
@@ -64,17 +64,25 @@ class Instance:
 
         return self._host_vars
 
-    def get_hostvar(self, key, default=None):
-        """Returns the value of the given key or the given default value if the
-        key is not in the instance's host_vars, its location's group_vars, or
-        the cluster's main group's group_vars (i.e., cluster_vars)."""
-
-        v = ChainMap(
+    def effective_vars(self):
+        """Generate a ChainMap with the various vars applied to the instance
+        ordered the same way ansible inventory would be applied.
+        Returns:
+            ChainMap : all vars applicable to the instance
+        """
+        return ChainMap(
             self.host_vars,
             self._cluster.instance_defaults.get("vars", {}),
             self.location.group.group_vars or {},
             self._cluster.group.group_vars,
         )
+
+    def get_hostvar(self, key, default=None):
+        """Returns the value of the given key or the given default value if the
+        key is not in the instance's host_vars, its location's group_vars, or
+        the cluster's main group's group_vars (i.e., cluster_vars)."""
+
+        v = self.effective_vars()
         return v.get(key, default)
 
     def get_setting(self, key, default=None) -> Any:


### PR DESCRIPTION
Take already existing bdr3 or bdr4 config into account for generating commit_scope during reconfigure to pgd5.

Ensure we use already defined `synchronous_replication_availability` and `bdr.global_commit_timeout` from bdr3 or bdr4 cluster to generate the pgd5 commit scope for CAMO enabled nodes.

Adjust default commit_scope rule values to match recommended values from BDR/testing team:
- timeout `60s`
- use `require_write_lead = true`

remove the unused bdr3/bdr4 vars mentioned above from config.yml file once we are done creating camo commit_scope.