### PR TITLE
TPA-618: EFM primary_slot_name

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -25,6 +25,12 @@
   reconfigure command to prepare for major PGD upgrade. Improve default
   value when no previous config exist.
 
+- TPA-618 Generate a primary_slot_name on primary for efm
+
+  Generate a primary_slot_name also on primary node to be used in case of
+  switchover, to ensure the switched primary will have a physical slot on
+  the new primary.
+
 ## v23.26 (2023-11-30)
 
 ### Minor changes

--- a/roles/postgres/config/tasks/main.yml
+++ b/roles/postgres/config/tasks/main.yml
@@ -262,6 +262,24 @@
 # TODO: This code doesn't permit a non-streaming replica to be set up
 # (i.e., one that depends entirely on log shipping).
 
+# generate a primary_slot_name on primary and replica node for efm
+# used during switchover to ensure the old primary uses
+# a physical slot for replication.
+- name: Configure primary_slot_name on primary
+  copy:
+    content: >
+      primary_slot_name = '{{ primary_slot_name }}'
+    dest: "{{ _include_dir }}/8901-primary_slot_name.conf"
+    owner: "{{ postgres_user }}"
+    group: "{{ postgres_group }}"
+    mode: 0644
+  when: >
+    ('primary' in role or 'replica' in role)
+    and failover_manager != 'repmgr'
+    and postgres_version is version('12', '>=')
+  notify:
+    - Note Postgres reload required
+
 - name: Write recovery configuration for replicas, if required
   when: >
     'replica' in role
@@ -281,16 +299,6 @@
     notify:
       - Note Postgres reload required
 
-  - name: Configure primary_slot_name
-    copy:
-      content: >
-        primary_slot_name = '{{ primary_slot_name }}'
-      dest: "{{ _include_dir }}/8901-primary_slot_name.conf"
-      owner: "{{ postgres_user }}"
-      group: "{{ postgres_group }}"
-      mode: 0644
-    notify:
-      - Note Postgres reload required
 
   - name: Set restore_command to point to a Barman server, if available
     set_fact:


### PR DESCRIPTION
Generate a primary_slot_name on primary node when using efm so that it can be used on `switchover` to ensure the use of a physical slot for the original primary on the new primary node.