### PR TITLE
Set maintenance_work_mem to 64MB by default

### DIFF
--- a/roles/postgres/config/templates/tpa.conf.j2
+++ b/roles/postgres/config/templates/tpa.conf.j2
@@ -8,7 +8,7 @@ tcp_keepalives_count = {{ tcp_keepalives_count|default(9) }}
 
 temp_buffers = {{ temp_buffers|default('16MB') }}
 work_mem = {{ work_mem|default('16MB') }}
-maintenance_work_mem = {{ maintenance_work_mem|default('1GB') }}
+maintenance_work_mem = {{ maintenance_work_mem|default('64MB') }}
 autovacuum_work_mem = {{ autovacuum_work_mem|default(-1) }}
 
 bgwriter_delay = {{ bgwriter_delay|default('200ms') }}

--- a/roles/postgres/config/vars/conf_tpa.yml
+++ b/roles/postgres/config/vars/conf_tpa.yml
@@ -7,7 +7,7 @@ tcp_keepalives_count: "{{ tcp_keepalives_count|default(9) }}"
 
 temp_buffers: "{{ temp_buffers|default('16MB') }}"
 work_mem: "{{ work_mem|default('16MB') }}"
-maintenance_work_mem: "{{ maintenance_work_mem|default('1GB') }}"
+maintenance_work_mem: "{{ maintenance_work_mem|default('64MB') }}"
 autovacuum_work_mem: "{{ autovacuum_work_mem|default(-1) }}"
 
 bgwriter_delay: "{{ bgwriter_delay|default('200ms') }}"


### PR DESCRIPTION
This greatly reduces the chance of hard failures, while causing only slight slowdown even on very large systems.

Fixes: TPA-629