### PR TITLE
Warn if 2q repositories are in use

### DIFF
--- a/architectures/lib/commands/check-repositories.yml
+++ b/architectures/lib/commands/check-repositories.yml
@@ -7,7 +7,9 @@
 
   tasks:
   - assert:
-      that: "{{ tpa_2q_repositories is not defined }}"
+      that: >
+        tpa_2q_repositories is not defined
+        or tpa_2q_repositories == []
       msg: >-
         WARNING: you are using deprecated 2ndQuadrant repositories, which will
         soon be decommissioned. Please use 'tpaexec reconfigure' to update to

--- a/architectures/lib/commands/check-repositories.yml
+++ b/architectures/lib/commands/check-repositories.yml
@@ -1,0 +1,16 @@
+---
+
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+- name: Check for old repositories
+  hosts: all
+
+  tasks:
+  - assert:
+      that: "{{ tpa_2q_repositories is not defined }}"
+      msg: >-
+        WARNING: you are using deprecated 2ndQuadrant repositories, which will
+        soon be decommissioned. Please use 'tpaexec reconfigure' to update to
+        EDB repositories 2.0
+    delegate_to: localhost
+    run_once: true

--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -1117,9 +1117,11 @@ case "$command" in
 
     cmd|ping|provision|deploy|upgrade|playbook|deprovision)
         time $command "$@"
+        playbook ${TPA_DIR}/architectures/lib/commands/check-repositories.yml
         ;;
 
     *)
         try_as_playbook_or_script "$@"
+        playbook ${TPA_DIR}/architectures/lib/commands/check-repositories.yml
         ;;
 esac


### PR DESCRIPTION
After running most tpaexec commands, run the new playbook "check-repositories.yml", which does nothing but check the inventory for one host and warn if tpa_2q_repositories is set.

Fixes: TPA-631