### PR TITLE
Respect package versions in the downloader

### DIFF
--- a/lib/filter_plugins/fnmatch.py
+++ b/lib/filter_plugins/fnmatch.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+
+from typing import Dict, List, Any
+import fnmatch as fnm
+
+def fnmatch(string: str, pattern: str) -> bool:
+    """Given a package version as returned by apt-cache, return True iff it
+    matches the package_spec
+    """
+    if (fnm.fnmatch(string, pattern)):
+        return True
+    return False
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            "fnmatch": fnmatch,
+        }

--- a/roles/pkg/download/tasks/os/Debian/download.yml
+++ b/roles/pkg/download/tasks/os/Debian/download.yml
@@ -19,6 +19,14 @@
 #
 # The final output contains packages that we need to download.
 
+- name: Resolve packages to specific versions
+  include_tasks: resolve-package.yml
+  loop: "{{ package_list }}"
+  loop_control:
+    loop_var: package_spec
+  when:
+    package_spec.find('=') > -1
+
 - name: Generate list of packages with all dependencies
   shell: |
     apt-cache depends \
@@ -33,14 +41,24 @@
   vars:
     _packages: "{{ package_list|mandatory|map('quote')|join(' ') }}"
 
+# The list we now have contains bare names of all packages, including
+# ones that we've resolved from a wildcard to a specific version. So we
+# remove the bare names of anything that's in versioned_package_list,
+# and download the rest of the output from the dependency resolution,
+# plus the original package list, which has been modified to include
+# specific versions if it contained wildcards. This merged list may
+# contain duplicates but that doesn't cause a problem.
+
 - name: Download packages with apt-get (for {{ ansible_distribution }} {{ ansible_distribution_major_version }})
   command: "apt-get download {{ _all_packages_and_dependencies }}"
   args:
     chdir: "{{ _download_dir }}"
   register: _apt_get_download
   vars:
+    dependencies: >
+      {{ _pkg_list.stdout_lines|reject('in', versioned_package_list|default([]))|list }}
     _all_packages_and_dependencies: >
-      {{ _pkg_list.stdout_lines|map('quote')|join(' ') }}
+      {{ ( dependencies + package_list )|map('quote')|join(' ') }}
   changed_when: >
     _apt_get_download.stdout_lines|length > 0
 

--- a/roles/pkg/download/tasks/os/Debian/download.yml
+++ b/roles/pkg/download/tasks/os/Debian/download.yml
@@ -19,9 +19,13 @@
 #
 # The final output contains packages that we need to download.
 
+- name: Create package list copy
+  set_fact:
+    copy_package_list: "{{ package_list }}"
+
 - name: Resolve packages to specific versions
   include_tasks: resolve-package.yml
-  loop: "{{ package_list }}"
+  loop: "{{ copy_package_list }}"
   loop_control:
     loop_var: package_spec
   when:
@@ -58,7 +62,7 @@
     dependencies: >
       {{ _pkg_list.stdout_lines|reject('in', versioned_package_list|default([]))|list }}
     _all_packages_and_dependencies: >
-      {{ ( dependencies + package_list )|map('quote')|join(' ') }}
+      {{ ( dependencies + copy_package_list )|map('quote')|join(' ') }}
   changed_when: >
     _apt_get_download.stdout_lines|length > 0
 

--- a/roles/pkg/download/tasks/os/Debian/resolve-package.yml
+++ b/roles/pkg/download/tasks/os/Debian/resolve-package.yml
@@ -34,4 +34,4 @@
 - name: Update package list with versioned package
   set_fact:
     versioned_package_list: "{{ versioned_package_list|default([]) + [package_name] }}"
-    package_list: "{{ package_list|reject('equalto', package_spec)|list + [package_name ~ '=' ~ matching_version] }}"
+    copy_package_list: "{{ copy_package_list|reject('equalto', package_spec)|list + [package_name ~ '=' ~ matching_version] }}"

--- a/roles/pkg/download/tasks/os/Debian/resolve-package.yml
+++ b/roles/pkg/download/tasks/os/Debian/resolve-package.yml
@@ -1,0 +1,37 @@
+---
+
+# © Copyright EnterpriseDB UK Limited 2015-2023 - All rights reserved.
+#
+# package_spec contains a specification with an '=', possibly including
+# wildcards after the '='. We look at apt's cache and find a package
+# matching the given name and specification, and add it to package_list,
+# removing the corresponding original entry. We also add the package name
+# to versioned_package_list so that we can later exclude it from being
+# downloaded independently of versioning.
+
+- name: Extract package name and version from {{ package_spec }}
+  set_fact:
+    package_name: "{{
+        package_spec.split('=')[0]
+      }}"
+    package_version: "{{
+        package_spec.split('=')[1]
+      }}"
+
+- name: Get available versions of {{ package_name }}
+  shell: >
+    apt-cache show -a {{ package_name }}
+    | grep Version
+    | cut -d' ' -f 2
+  register: package_version_list
+
+- name: Find matching versions of {{ package_name }}
+  set_fact:
+    matching_version: "{{ item }}"
+  loop: "{{ package_version_list.stdout_lines }}"
+  when: item|fnmatch(package_version)
+
+- name: Update package list with versioned package
+  set_fact:
+    versioned_package_list: "{{ versioned_package_list|default([]) + [package_name] }}"
+    package_list: "{{ package_list|reject('equalto', package_spec)|list + [package_name ~ '=' ~ matching_version] }}"

--- a/roles/pkg/download/tasks/os/Debian/resolve-package.yml
+++ b/roles/pkg/download/tasks/os/Debian/resolve-package.yml
@@ -29,7 +29,7 @@
   set_fact:
     matching_version: "{{ item }}"
   loop: "{{ package_version_list.stdout_lines }}"
-  when: item|fnmatch(package_version)
+  when: item|fnmatch(package_version) or item|fnmatch('*:' + package_version)
 
 - name: Update package list with versioned package
   set_fact:


### PR DESCRIPTION
When using the downloader on a Debian-family system, we now perform our own fnmatch-style globbing on any package versions specified in config.yml, enabling constructions like `bdr_package_version: 4:5.0.*` to behave in the same way as when the downloader is not in use.

Fixes: TPA-463
Fixes: TPA-583