### PR TITLE
Enable disabling repository checks

### DIFF
--- a/roles/init/tasks/repos.yml
+++ b/roles/init/tasks/repos.yml
@@ -34,6 +34,7 @@
     that:
       edb_repositories is not empty
       or bdr_version|default('0') is not version('5', '>=')
+      or disable_repository_checks|default(false)
     fail_msg: >-
       You must set edb_repositories to use the PGD-Always-ON architecture
 


### PR DESCRIPTION
The new variable "disable_repository_checks" can be set to true in config.yml to bypass the usual check for EDB repositories when deploying the PGD-Always-ON architecture.

Fixes: TPA-616