### PR TITLE
Make Patroni take over an entire cluster instead of only the primary

### DIFF
--- a/roles/final/tasks/main.yml
+++ b/roles/final/tasks/main.yml
@@ -31,7 +31,7 @@
     'postgres' in role
     and 'replica' in role
     and not pgdata_initialised
-    and failover_manager not in ['repmgr', 'patroni']
+    and failover_manager not in ['repmgr']
     and not ('bdr' in role and 'readonly' in role)
 
 - include_role:

--- a/roles/init/tasks/postgres.yml
+++ b/roles/init/tasks/postgres.yml
@@ -257,6 +257,8 @@
 - name: Override "primary_slot_name" when using Patroni
   set_fact:
     primary_slot_name: "{{ inventory_hostname|regex_replace('[^a-zA-Z0-9_]', '_') }}"
+  when: >
+    failover_manager == 'patroni'
 
 - name: Add postgres libs and PGHOST to target_environment
   set_fact:

--- a/roles/init/tasks/postgres.yml
+++ b/roles/init/tasks/postgres.yml
@@ -249,6 +249,15 @@
 - set_fact:
     harp_manager_user: "{{ harp_manager_user|default(current_harp_manager_user| default(default_harp_manager_user)) }}"
 
+# Patroni manages replication slots, and we should use the same name it expects
+# i.e., the same name which is provided to the `name` Patroni setting (TPA uses
+# the inventory hostname as `name`). The regex applied here is the same one
+# used by Patroni when handling the member name -- see
+# `slot_name_from_member_name` function in Patroni code
+- name: Override "primary_slot_name" when using Patroni
+  set_fact:
+    primary_slot_name: "{{ inventory_hostname|regex_replace('[^a-zA-Z0-9_]', '_') }}"
+
 - name: Add postgres libs and PGHOST to target_environment
   set_fact:
     target_environment: "{{ target_environment|combine(_task_environment) }}"

--- a/roles/patroni/config/tasks/config.yml
+++ b/roles/patroni/config/tasks/config.yml
@@ -177,6 +177,13 @@
     backup is defined
     and backup is not empty
 
+- name: Update patroni config with permanent physical slots
+  include_role:
+    name: config/add_to_obj
+  vars:
+    object_varname: patroni_conf
+    object_contents: "{{ _patroni_conf_permanent_slots }}"
+
 - name: Finally apply any user defined overrides
   include_role:
     name: config/add_to_obj

--- a/roles/patroni/config/vars/config.yml
+++ b/roles/patroni/config/vars/config.yml
@@ -163,6 +163,21 @@ _patroni_conf_backup:
         - name: "{{ backup|default('')|backup_slot_name }}"
           type: physical
 
+# permanent physical replication slots for members, so they don't get dropped
+# while Patroni is taking management over during the first `tpaexec deploy`.
+# The permanent slots will also avoid having the slots dropped if a node faces
+# a temporary disconnection from the cluster.
+_patroni_conf_permanent_slots:
+  bootstrap:
+    dcs:
+      slots: >-
+        {%- set _slots = {} -%}
+        {%- for h in groups['patroni']|sort -%}
+        {%-   set slot_name = hostvars[h].primary_slot_name -%}
+        {%-   set _ = _slots.update({slot_name: {'type': 'physical'}}) -%}
+        {%- endfor -%}
+        {{ _slots }}
+
 # Build the Dynamic Config first from defaults, then from any bootstrap.dcs settings supplied
 # in `config.yml`, then finally from `patroni_dynamic_conf_settings` supplied in `config.yml`.
 # This is used to update running clusters once bootstrapped and also the initial bootstrap

--- a/roles/patroni/facts/tasks/state.yml
+++ b/roles/patroni/facts/tasks/state.yml
@@ -9,20 +9,23 @@
 # manager, and patroni has not been initialised (no existing state is present in
 # the DCS), TPA will:
 #
-# 1. Create a single standalone PostgreSQL server using the same method that
-#   it does for other cluster types and failover managers. TPA will create
-#   configuration files, initialise the database, start the server with the
-#   `postgres` systemd service unit configured with TPA, establish what users
-#   should be created, add extension configuration, etc.
+# 1. Create the primary and standbys using the same method that it does for
+#   other cluster types and failover managers. TPA will create configuration
+#   files, initialise the database, start the server with the `postgres` systemd
+#   service unit configured with TPA, establish what users should be created,
+#   add extension configuration, etc.
 # 2. create a Patroni configuration with bootstrap settings that will initialise
 #   the DCS with settings and PostgreSQL configuration generated and provided by
 #   TPA.
 # 3. start Patroni on the primary node, where Patroni will populate the DCS with
 #   configuration from the bootstrap configuration in the Patroni config file,
-#   read the state of the database, and promote itself to be the leader.
-# 4. start Patroni on secondary nodes, that will connect to the DCS and see
-#   there is an existing cluster, establishing a connection with the primary
-#   and perform replica creation.
+#   read the state of the database, and promote itself to be the leader. The DCS
+#   configuration will contain permanent physical replication slots configured
+#   for the members, so we avoid having the slots dropped while Patroni is
+#   taking the cluster management over.
+# 4. start Patroni on secondary nodes. Based on the information from the DCS and
+#   on the running Postgres instance Patroni will decide to do nothing else, and
+#   it will simply take over management of the running nodes.
 # 5. detect the Patroni cluster is initialised and perform any clean up that is
 #   required, including removing configuration files for PostgreSQL laid down by
 #   TPA in step 1 above.

--- a/roles/patroni/final/tasks/init.yml
+++ b/roles/patroni/final/tasks/init.yml
@@ -16,12 +16,10 @@
 # can start the replicas who will start to sync from the primary
 # automatically.
 
+# Make Patroni take management over on the primary
+# We need to start with the primary so we avoid that Patroni would promote a
+# replica when taking over the cluster management
 - block:
-  - include_role:
-      name: postgres/restart
-    vars:
-      postgres_service_end_state: stopped
-
   - include_tasks: config.yml
 
   - include_role:
@@ -34,10 +32,14 @@
     and (patroni_cluster.members is not defined
       or patroni_cluster.members is empty)
 
+# Update facts which will be used by Patroni on the replicas
+# That's required so the replicas will have the updated facts when being taken
+# over by Patroni
 - include_role:
     name: patroni/facts
     tasks_from: gather
 
+# Make Patroni take management over on the replicas
 - block:
   - include_tasks: config.yml
 
@@ -50,3 +52,13 @@
   when: >
     'replica' in role
     and patroni_cluster.members|selectattr('Member', 'eq', inventory_hostname)|list is empty
+
+# This will take care of "stopping" the `postgres` systemd unit and making
+# Patroni start Postgres through `pg_ctl`
+- name: Issue a postgresql restart so Patroni can take it over
+  include_role:
+    name: patroni/api
+    tasks_from: restart
+  run_once: true
+  when:
+    patroni_initialised

--- a/roles/patroni/final/tasks/init.yml
+++ b/roles/patroni/final/tasks/init.yml
@@ -9,12 +9,10 @@
 # DCS config.
 
 # So first of all we read the cluster state from the DCS, then we
-# start patroni on the only primary if the DCS is empty. This ensures
-# that the empty replicas do not try to initialise new databases and
-# form a cluster between them as this would result in a mismatch in
-# system ID in the DCS. Then once the DCS has correct information we
-# can start the replicas who will start to sync from the primary
-# automatically.
+# start patroni on the primary if the DCS is empty. This ensures that the
+# expected Postgres node is set as leader in the DCS. Then once the DCS has
+# correct information we can start Patroni on the standbys who will be
+# assigned with the correct role in the DCS (`replica`)
 
 # Make Patroni take management over on the primary
 # We need to start with the primary so we avoid that Patroni would promote a

--- a/roles/patroni/final/tasks/main.yml
+++ b/roles/patroni/final/tasks/main.yml
@@ -5,7 +5,6 @@
 - include_tasks: init.yml
   when:
     not patroni_initialised
-    and 'primary' in role
 
 # All facts for configuration should be available by this stage so this is
 # where the patroni YAML config file can be created or updated.


### PR DESCRIPTION
This PR changes the way Patroni clusters are deployed. So far TPA would do the following:

* TPA: bootstrap the primary
* Patroni: take over management of the primary
* Patroni: bootstrap replicas

With the changes it will now do the following:

* TPA: bootstrap primary and replicas
* Patroni: take over management of the cluster

A couple things are important for that to work with Patroni:

* Patroni needs to be started first on the node that is expected to be the primary, then on nodes that are expected to be replicas, otherwise it would promote one of the replicas and demote the primary.
* Patroni configuration needs to contain member slots configured as permanent physical slots. That avoids that Patroni would drop the replication slots used by the original cluster which was deployed by TPA.

That's better aligned with how other HA tools are deployed by TPA.