### PR TITLE
Separate dsn attributes for streaming barman client

### DIFF
--- a/roles/barman/templates/barman.d.conf.j2
+++ b/roles/barman/templates/barman.d.conf.j2
@@ -7,7 +7,7 @@ archiver = "{{ _barman_archiver }}"
 {% endif %}
 ssh_command = "ssh -q {{ postgres_user }}@{{ target }}"
 conninfo = "{{ hostvars[target].node_dsn|dbname('postgres', user='barman') }} {{ barman_client_dsn_attributes }}"
-streaming_conninfo = "{{ hostvars[target].node_dsn|dbname('postgres', user='streaming_barman') }} {{ barman_client_dsn_attributes }}"
+streaming_conninfo = "{{ hostvars[target].node_dsn|dbname('postgres', user='streaming_barman') }} {{ streaming_barman_client_dsn_attributes }}"
 streaming_archiver = on
 slot_name = "{{ slot_name }}"
 {% if _barman_log_file != default_barman_log_file %}

--- a/roles/init/tasks/postgres.yml
+++ b/roles/init/tasks/postgres.yml
@@ -469,6 +469,8 @@
   set_fact:
     postgres_client_dsn_attributes: "{{ postgres_client_dsn_attributes|default('') }}"
     replica_client_dsn_attributes: "{{ replica_client_dsn_attributes|default('') }}"
+    streaming_barman_client_dsn_attributes: >
+      "{{ streaming_barman_client_dsn_attributes|default(barman_client_dsn_attributes)|default('') }}"
     barman_client_dsn_attributes: "{{ barman_client_dsn_attributes|default('') }}"
     repmgr_client_dsn_attributes: "{{ repmgr_client_dsn_attributes|default('') }}"
     bdr_client_dsn_attributes: "{{ bdr_client_dsn_attributes|default('') }}"


### PR DESCRIPTION
Enable separate dsn attributes for the streaming barman user, so that users can use 'ssl_mode=verify-full', which means the user name must match the certificate's user and therefore separate certificates are needed for separate users.

Fixes: TPA-637