### PR TITLE
Fix "streaming_barman_client_dsn_attributes" var

### DIFF
--- a/roles/init/tasks/postgres.yml
+++ b/roles/init/tasks/postgres.yml
@@ -469,8 +469,8 @@
   set_fact:
     postgres_client_dsn_attributes: "{{ postgres_client_dsn_attributes|default('') }}"
     replica_client_dsn_attributes: "{{ replica_client_dsn_attributes|default('') }}"
-    streaming_barman_client_dsn_attributes: >
-      "{{ streaming_barman_client_dsn_attributes|default(barman_client_dsn_attributes)|default('') }}"
+    streaming_barman_client_dsn_attributes: >-
+      {{ streaming_barman_client_dsn_attributes|default(barman_client_dsn_attributes)|default('') }}
     barman_client_dsn_attributes: "{{ barman_client_dsn_attributes|default('') }}"
     repmgr_client_dsn_attributes: "{{ repmgr_client_dsn_attributes|default('') }}"
     bdr_client_dsn_attributes: "{{ bdr_client_dsn_attributes|default('') }}"


### PR DESCRIPTION
Removing line feed and trailing blank lines. Otherwise, we might see an error like this:

stderr_lines": ["EXCEPTION: Source contains parsing errors: '/etc/barman.d/machine.conf'", "\t[line  7]: '\"\\n'", "See log file for more details."