### PR TITLE
Point link for comm scope to cs ref

### DIFF
--- a/docs/src/bdr.md
+++ b/docs/src/bdr.md
@@ -140,7 +140,7 @@ is mentioned in `bdr_node_groups`), it will join that group instead of
 ### bdr_commit_scopes
 
 This is an optional list of
-[commit scopes](https://www.enterprisedb.com/docs/pgd/latest/durability/group-commit/)
+[commit scopes](https://www.enterprisedb.com/docs/pgd/latest/reference/commit-scopes/)
 that must exist in the PGD database (available for PGD 4.1 and above).
 
 ```yaml


### PR DESCRIPTION
Updated link to point to the commit scope reference page rather than a page for a single commit scope (group commit).

