### PR TITLE
Use correct package names for repmgr in PGDG repos

### DIFF
--- a/roles/repmgr/pkg/tasks/list-packages.yml
+++ b/roles/repmgr/pkg/tasks/list-packages.yml
@@ -5,6 +5,16 @@
 - include_role: name=pkg/add_to_list
   vars:
     list_contents: "{{
+      (ansible_os_family == 'RedHat'
+        and edb_repositories is empty
+        and tpa_2q_repositories is empty)
+        and default_list_contents|select('match', 'repmgr_')|list is empty
+      | ternary(
+        default_list_contents|map('replace', 'repmgr', 'repmgr_')|list,
+        default_list_contents,
+      )
+      }}"
+    default_list_contents: "{{
         repmgr_packages[postgres_flavour]
         |packages_for(ansible_os_family, repmgr_package_version)
       }}"


### PR DESCRIPTION
If we're installing repmgr on a RedHat-family system from PGDG repos, the package will be named repmgr_nn not repmgrnn .

Fixes: TPA-576