### PR TITLE
Sanitise hostnames with --cluster-prefixed-hostnames

### DIFF
--- a/lib/tpaexec/architecture.py
+++ b/lib/tpaexec/architecture.py
@@ -588,7 +588,8 @@ class Architecture(object):
         (args["hostnames"], args["ip_addresses"]) = self.hostnames(self.num_instances())
         if args.get("cluster_prefixed_hostnames"):
             args["hostnames"] = [
-                args["cluster_name"] + "-" + hostname for hostname in args["hostnames"]
+                re.sub("[^a-z0-9-]", "-", args["cluster_name"].lower()) + "-" + hostname
+                for hostname in args["hostnames"]
             ]
 
         # Figure out how to get the desired distribution.


### PR DESCRIPTION
When the --cluster-prefixed-hostnames argument is given to `tpaexec configure`, use a version of the cluster name that doesn't contain characters that aren't valid in hostnames.

Fixes: TPA-644