### PR TITLE
Exit correctly if repo check fails

### DIFF
--- a/architectures/lib/commands/check-repositories.yml
+++ b/architectures/lib/commands/check-repositories.yml
@@ -16,3 +16,4 @@
         EDB repositories 2.0
     delegate_to: localhost
     run_once: true
+    ignore_errors: yes

--- a/bin/tpaexec
+++ b/bin/tpaexec
@@ -1155,11 +1155,15 @@ case "$command" in
 
     cmd|ping|provision|deploy|upgrade|playbook|deprovision)
         time $command "$@"
+        real_exit_status=$?
         playbook ${TPA_DIR}/architectures/lib/commands/check-repositories.yml
+        exit $real_exit_status
         ;;
 
     *)
         try_as_playbook_or_script "$@"
+        real_exit_status=$?
         playbook ${TPA_DIR}/architectures/lib/commands/check-repositories.yml
+        exit $real_exit_status
         ;;
 esac


### PR DESCRIPTION
If the `assert` task that checks we're not still using 2ndQuadrant repositories fails, the eventual exit status from tpaexec should still reflect the status of the action that the user asked for.