### PR TITLE
Remove deprecated --use-community-ansible from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get -y update && \
     ln -sf ${TPA_DIR}/bin/tpaexec /usr/local/bin && \
     mkdir /opt/2ndQuadrant/ && \
     ln -sf ${TPA_DIR} /opt/2ndQuadrant/TPA && \
-    tpaexec setup --use-community-ansible && \
+    tpaexec setup && \
     tpaexec selftest && \
     (cd "${TPA_DIR}" && git describe --tags >VERSION) && \
     \


### PR DESCRIPTION
Support for `--use-community-ansible` and `--use-2q-ansible` was removed in [v23.30](https://github.com/EnterpriseDB/tpa/pull/156/files#diff-0d8e64daf3fcee153ab1a24efadd67f716b4ea8172183990ccf1488d6dac0545L287-L293).

Running `docker build -t tpa/tpaexec .` per the [docs](https://www.enterprisedb.com/docs/tpa/latest/reference/INSTALL-docker/#quick-start) currently fails with the error:

> ERROR: unrecognised option: --use-community-ansible

This change continues with the intent of defaulting to Community Ansible 8