### PR TITLE
Removed the forward slash at the end of the home path.

### DIFF
--- a/roles/etcd/config/tasks/main.yml
+++ b/roles/etcd/config/tasks/main.yml
@@ -15,7 +15,7 @@
     group: "{{ etcd_group }}"
     system: yes
     comment: "etcd key-value store"
-    home: /var/lib/etcd/
+    home: /var/lib/etcd
     password: '!'
     shell: /bin/nologin
   when: >


### PR DESCRIPTION
That extra forward slash at the end of the path seems unnecessary. When the account is created in advance with /var/lib/etcd, the ansible "user" module determines that it needs to update the account because of such a difference. Some security programs prevent root from running other programs (i.e. usermod) that modify /etc/passwd. Excerpt of an ansible log with such a case:
'"msg": "usermod: cannot open /etc/passwd\\n"'