### PR TITLE
Fixes #248: Adding efm-post-config hook

### DIFF
--- a/docs/src/task-selection.md
+++ b/docs/src/task-selection.md
@@ -45,8 +45,8 @@ To prevent bootstrap and ssh tasks from ever running, put the following
 into `config.yml`:
 
 ```yaml
-    cluster_vars:
-      excluded_tasks:
+cluster_vars:
+    excluded_tasks:
         - bootstrap
         - ssh
 ```
@@ -55,290 +55,294 @@ into `config.yml`:
 
 The following selectors are supported for either inclusion or exclusion:
 
-- barman
+-   barman
 
     Tasks related to Barman.
 
-- bdr
+-   bdr
 
     Tasks related to setting up BDR, including when it is as used within
     a PGD cluster. If this selector is excluded, TPA will still install
     and configure the extension as specified in config.yml, but won't
     create the node groups or try to join the nodes.
 
-- create_pgd_proxy_system_user
+-   create_pgd_proxy_system_user
 
     Tasks which creates the system user for pgd_proxy
 
-- create_postgres_system_user
+-   create_postgres_system_user
 
     Tasks which creates the system user for postgres
 
-- efm
+-   efm
 
     Tasks related to EFM.
 
-- etcd
+-   etcd
 
     Tasks related to etcd.
 
-- first-backup
+-   first-backup
 
     Tasks which ensure the minimum number of barman backups exist.
 
-- haproxy
+-   haproxy
 
     Tasks related to haproxy.
 
-- harp
+-   harp
 
     Tasks related to harp.
 
-- patroni
+-   patroni
 
     Tasks related to patroni.
 
-- pem-agent
+-   pem-agent
 
     Tasks related to the PEM agent.
 
-- pem-server
+-   pem-server
 
     Tasks related to the PEM server.
 
-- pem-webserver
+-   pem-webserver
 
     Tasks related to configuring the web server on a PEM server.
 
-- pg-backup-api
+-   pg-backup-api
 
     Tasks related to Barman's Postgres backup API.
 
-- pgbouncer
+-   pgbouncer
 
     Tasks related to PgBouncer.
 
-- pgd-proxy
+-   pgd-proxy
 
     Tasks related to PGD Proxy.
 
-- pglogical
+-   pglogical
 
     Tasks related to pglogical.
 
-- pkg
+-   pkg
 
     Tasks which install packages using the system package manager.
 
-- post-deploy
+-   post-deploy
 
     The post-deploy hook, if one is defined.
 
-- postgres
+-   postgres
 
     Tasks related to postgres.
 
-- replica
+-   replica
 
     Tasks which are run and instances acting as postgres replicas.
 
-- repmgr
+-   repmgr
 
     Tasks related to repmgr.
 
-- restart
+-   restart
 
     Tasks which restart services
 
-- sys
+-   sys
 
     Tasks related to system setup before any tasks specific to postgres
     or related software.
 
-- zabbix-agent
+-   zabbix-agent
 
     Tasks related to the zabbix agent.
 
 The following selectors are supported only for exclusion:
 
-- artifacts
+-   artifacts
 
     Tasks related to [artifacts](artifacts.md).
 
-- barman-clean
+-   barman-clean
 
     Tasks which clean up the Barman build directory if Barman is being
     built from source.
 
-- barman-pre-config
+-   barman-pre-config
 
     The barman-pre-config hook, if one is defined.
 
-- bdr-pre-node-creation
+-   bdr-pre-node-creation
 
     The bdr-pre-node-creation hook, if one is defined.
 
-- bdr-post-group-creation
+-   bdr-post-group-creation
 
     The bdr-post-group-creation hook, if one is defined.
 
-- bdr-pre-group-join
+-   bdr-pre-group-join
 
     The bdr-pre-group-join hook, if one is defined.
 
-- bootstrap
+-   bootstrap
 
     Tasks which ensure that python and other minimal dependencies are
     present before the rest of the deploy runs. Exclude this only if you
     are sure you have manually installed the relevant requirements.
 
-- build-clean
+-   build-clean
 
     Tasks which clean up build directories for any software that is
     being built from source.
 
-- build-configure
+-   build-configure
 
     Tasks which configure any software that is being built from source.
 
-- cloudinit
+-   cloudinit
 
     Tasks which are run only on hosts managed by cloud-init.
 
-- commit-scopes
+-   commit-scopes
 
     Tasks related to configuration of BDR commit scopes.
 
-- config
+-   config
 
     Tasks which create config files.
 
-- efm-pre-config
+-   efm-pre-config
 
     The efm-pre-config hook, if one is defined.
 
-- fs
+-   efm-post-config
+
+    The efm-post-config hook, if one is defined.
+
+-   fs
 
     Tasks related to setting up additional [volumes](volumes.md) on
     instances.
 
-- hostkeys
+-   hostkeys
 
     Tasks which set up [ssh host keys](manage_ssh_hostkeys.md).
 
-- hostname
+-   hostname
 
     Tasks which set the hostname.
 
-- hosts
+-   hosts
 
     Tasks which [add entries to /etc/hosts](hosts.md)
 
-- initdb
+-   initdb
 
     Tasks which run initdb.
 
-- local-repo
+-   local-repo
 
     Tasks which set up [local package repositories](local-repo.md).
 
-- locale
+-   locale
 
     Tasks which install [locale support](locale.md).
 
-- openvpn
+-   openvpn
 
     Tasks which set up OpenVPN.
 
-- pg-backup-api-clean
+-   pg-backup-api-clean
 
     Tasks which clean up the build directory if the Postgres backup API
     is being built from source.
 
-- pgbouncer-config
+-   pgbouncer-config
 
     Tasks which create configuration files for pgbouncer.
 
-- pgpass
+-   pgpass
 
     Tasks which create the [.pgpass](pgpass.md) file.
 
-- post-repo
+-   post-repo
 
     The post-repo hook, if one is defined.
 
-- postgres-clean
+-   postgres-clean
 
     Tasks which clean up the build directory if postgres is being built
     from source.
 
-- postgres-config
+-   postgres-config
 
     The postgres-config hook, if one is defined.
 
-- postgres-config-final
+-   postgres-config-final
 
     The postgres-config-final hook, if one is defined.
 
-- pre-deploy
+-   pre-deploy
 
     The pre-deploy hook, if one is defined.
 
-- pre-initdb
+-   pre-initdb
 
     The pre-initdb hook, if one is defined.
 
-- replication-sets
+-   replication-sets
 
     Tasks related to witness-only replication sets on a BDR3 cluster.
 
-- repmgr-clean
+-   repmgr-clean
 
     Tasks which clean up the build directory if repmgr is being built
     from source.
 
-- repmgr-configure
+-   repmgr-configure
 
     Tasks which configure repmgr if it is being built from source.
 
-- repo
+-   repo
 
     Tasks which set up package repositories.
 
-- rsyslog
+-   rsyslog
 
     Tasks related to rsyslog.
 
-- service
+-   service
 
     Tasks related to system services, including configuration and
     restarting.
 
-- src
+-   src
 
     Tasks which build and install packages from source.
 
-- ssh
+-   ssh
 
     Tasks related to setting up ssh between instances.
 
-- sysctl
+-   sysctl
 
     Tasks which set and reload sysctl settings.
 
-- sysstat
+-   sysstat
 
     Tasks releated to the sysstat service.
 
-- tpa
+-   tpa
 
     Tasks related to TPA's own files installed on instances.
 
-- user
+-   user
 
     Tasks related to setting up system users.
 
-- watchdog
+-   watchdog
 
     Tasks related to the kernel watchdog on a patroni cluster.
 
@@ -346,28 +350,28 @@ The following selectors are supported only for exclusion:
 
 The following selectors apply only for execution of `tpaexec test`:
 
-- camo
+-   camo
 
     Tasks related to testing CAMO in a BDR or PGD cluster.
 
-- ddl
+-   ddl
 
     Tasks related to testing DDL in a BDR or PGD cluster.
 
-- fail
+-   fail
 
     Tasks which abort tests if a problem is detected. Exclude this
     selector to run tests regardless of failures.
 
-- pgbench
+-   pgbench
 
     Tasks which run pgbench.
 
-- sys
+-   sys
 
     Tasks which run system-level tests.
 
-- barman, bdr, haproxy, pg-backup-api, pgbouncer, pgd-proxy, postgres,
-  repmgr,
+-   barman, bdr, haproxy, pg-backup-api, pgbouncer, pgd-proxy, postgres,
+    repmgr,
 
     Tasks which test the various software components.

--- a/docs/src/tpaexec-hooks.md
+++ b/docs/src/tpaexec-hooks.md
@@ -98,6 +98,16 @@ generating any efm configuration.
 
 An example use of this hook is to install efm helper scripts.
 
+### efm-post-config
+
+TPA invokes `hooks/efm-post-config.yml` at the exact end of
+configuration of EFM,
+after generating efm configuration, but before running other roles and
+finally restarting EFM.
+
+Examples of using this hook is to set custom taiilor'ed config, or
+change sudo permissions as by your environments requirements.
+
 ### harp-config
 
 TPA invokes `hooks/harp-config.yml` after generating HARP configuration

--- a/roles/efm/config/tasks/main.yml
+++ b/roles/efm/config/tasks/main.yml
@@ -1,13 +1,12 @@
 ---
-
 # © Copyright EnterpriseDB UK Limited 2015-2025 - All rights reserved.
 
 - name: Ensure efm configuration directory exists
   file:
-    path: "{{ efm_conf_dir }}"
+    path: '{{ efm_conf_dir }}'
     owner: efm
     group: efm
-    mode: "0755"
+    mode: '0755'
     state: directory
 
 - name: Include role postgres/createuser
@@ -15,24 +14,24 @@
   vars:
     username: efm
     role_attrs:
-    - superuser
-    password_encryption: "{{ efm_user_password_encryption }}"
+      - superuser
+    password_encryption: '{{ efm_user_password_encryption }}'
 
 - name: Include efm-pre-config hook
-  include_tasks: "{{ hook }}"
+  include_tasks: '{{ hook }}'
   when: >
     lookup('first_found', dict(files=hook, skip=True))
     and task_selector|permits('efm-pre-config')
   vars:
-    hook: "{{ cluster_dir }}/hooks/efm-pre-config.yml"
+    hook: '{{ cluster_dir }}/hooks/efm-pre-config.yml'
 
 - name: Allow efm user to run db function as {{ postgres_user }}
   community.general.sudoers:
-    name: "efm_run_as_{{ postgres_user }}"
+    name: 'efm_run_as_{{ postgres_user }}'
     state: present
     user: efm
-    runas: "{{ postgres_user }}"
-    commands: "{{ efm_bin_dir }}/efm_db_functions"
+    runas: '{{ postgres_user }}'
+    commands: '{{ efm_bin_dir }}/efm_db_functions'
   when: >
     failover_manager == "efm"
 
@@ -45,24 +44,23 @@
 - name: Encrypt efm password
   shell: >
     "{{ efm_bin_dir }}"/efm encrypt "{{ cluster_name }}" --from-env
-  environment: "{{ target_environment|combine(_task_environment) }}"
+  environment: '{{ target_environment|combine(_task_environment) }}'
   vars:
     _task_environment:
-      EFMPASS: "{{ efm_password }}"
+      EFMPASS: '{{ efm_password }}'
   register: efm_encrypted_pass_output
   changed_when: false
   no_log: true
 
 - name: Configure efm for syslog
   block:
-
     - name: Load syslog_efm_conf_settings
       include_vars:
         file: log-server-defined.yml
 
     - name: Configure efm for syslog
       set_fact:
-        efm_conf_settings: "{{ syslog_efm_conf_settings|combine(efm_conf_settings) }}"
+        efm_conf_settings: '{{ syslog_efm_conf_settings|combine(efm_conf_settings) }}'
 
   when:
     - log_server is defined
@@ -73,14 +71,14 @@
 # check that .properties and .nodes files exist
 - name: Check if {{ efm_conf_dir }}/{{ cluster_name }}.properties file exists
   stat:
-    path: "{{ efm_conf_dir }}/{{ cluster_name }}.properties"
+    path: '{{ efm_conf_dir }}/{{ cluster_name }}.properties'
     get_checksum: false
     get_mime: false
   register: efm_cluster_prop
 
 - name: Check if {{ efm_conf_dir }}/{{ cluster_name }}.nodes file exists
   stat:
-    path: "{{ efm_conf_dir }}/{{ cluster_name }}.nodes"
+    path: '{{ efm_conf_dir }}/{{ cluster_name }}.nodes'
     get_checksum: false
     get_mime: false
   register: efm_cluster_nodes
@@ -97,7 +95,7 @@
 # check if the raw folder exists (2nd deploy for new clusters using /raw already)
 - name: Check if {{ efm_conf_dir }}/raw folder exists
   stat:
-    path: "{{ efm_conf_dir }}/raw"
+    path: '{{ efm_conf_dir }}/raw'
     get_checksum: false
     get_mime: false
   register: efm_raw
@@ -105,23 +103,23 @@
 # creates the raw subfolder for new clusters (no .properties exists)
 - name: Ensure raw folder exists for new clusters
   file:
-    path: "{{ efm_conf_dir }}/raw"
+    path: '{{ efm_conf_dir }}/raw'
     state: directory
     owner: efm
     group: efm
-    mode: "0755"
+    mode: '0755'
   when: >
     not efm_cluster_prop.stat.exists
 
 # For new clusters, the raw subfolder is created to contain versions of the .nodes and .properties files which
 # can be edited without causing EFM to restart. Configuration changes to these files are propogated to their top-level
 # counterparts using the 'efm upgrade-conf' command. On existing clusters that already have EFM configuration files,
-# the raw subfolder is not created and the .nodes and .properties are copied to the top-level only if the template's content 
+# the raw subfolder is not created and the .nodes and .properties are copied to the top-level only if the template's content
 # does not match what has already been configured in the respective files. The 'efm_use_raw' fact encapsulates the boolean
 # state of using the 'raw' subfolder for the reasons explained above.
 - set_fact:
-    efm_use_raw: "{{ (not (efm_cluster_prop.stat.exists and efm_cluster_nodes.stat.exists) or efm_raw.stat.exists) }}"
-    
+    efm_use_raw: '{{ (not (efm_cluster_prop.stat.exists and efm_cluster_nodes.stat.exists) or efm_raw.stat.exists) }}'
+
 # set the correct path for next steps
 - set_fact:
     raw: "{{ efm_use_raw|ternary('/raw', '')}}"
@@ -130,27 +128,27 @@
 - name: Install efm.properties for {{ cluster_name }}
   template:
     src: efm.properties.j2
-    dest: "{{ efm_conf_dir }}{{ raw }}/{{ cluster_name }}.properties"
+    dest: '{{ efm_conf_dir }}{{ raw }}/{{ cluster_name }}.properties'
     owner: efm
     group: efm
-    mode: "0640"
+    mode: '0640'
   register: efm_properties
   vars:
-    efm_encrypted_pass: "{{ efm_encrypted_pass_output.stdout }}"
+    efm_encrypted_pass: '{{ efm_encrypted_pass_output.stdout }}'
   notify:
     - Note efm restart required
 
 - name: Install efm.nodes
   template:
     src: efm.nodes.j2
-    dest: "{{ efm_conf_dir }}{{ raw }}/{{ cluster_name }}.nodes"
+    dest: '{{ efm_conf_dir }}{{ raw }}/{{ cluster_name }}.nodes'
     owner: efm
     group: efm
-    mode: "0640"
+    mode: '0640'
   register: efm_nodes
   vars:
     node_ips: "{{
-        groups['role_efm'] | map('extract', hostvars, ['ip_address']) | product([efm_bind_port]) | map('join', ':') | join('\n')
+      groups['role_efm'] | map('extract', hostvars, ['ip_address']) | product([efm_bind_port]) | map('join', ':') | join('\n')
       }}"
     node_hostnames: "{{ groups['role_efm'] | product([efm_bind_port]) | map('join', ':') | join('\n') }}"
   notify:
@@ -162,9 +160,9 @@
 # or if the top-level .properties or .nodes files are removed and need to be
 # re-populated from their raw counterparts using the efm upgrade-conf command.
 - name: Add useful comments to efm properties and nodes files
-  command: "{{ efm_bin_dir }}/efm upgrade-conf {{ cluster_name }} -source {{ efm_conf_dir }}{{ raw }}"
+  command: '{{ efm_bin_dir }}/efm upgrade-conf {{ cluster_name }} -source {{ efm_conf_dir }}{{ raw }}'
   args:
-    chdir: "{{ efm_conf_dir }}"
+    chdir: '{{ efm_conf_dir }}'
   become: true
   become_user: efm
   when:
@@ -177,7 +175,15 @@
 - name: Install efm notification script
   template:
     src: efm.notification.sh.j2
-    dest: "{{ efm_conf_dir }}/{{ cluster_name }}-efm.notification.sh"
+    dest: '{{ efm_conf_dir }}/{{ cluster_name }}-efm.notification.sh'
     owner: efm
     group: efm
-    mode: "0750"
+    mode: '0750'
+
+- name: Include efm-post-config hook
+  include_tasks: '{{ hook }}'
+  when: >
+    lookup('first_found', dict(files=hook, skip=True))
+    and task_selector|permits('efm-post-config')
+  vars:
+    hook: '{{ cluster_dir }}/hooks/efm-post-config.yml'


### PR DESCRIPTION
## Description
See issue #248 for a description of the issue I am trying to resolve.

## Fix
With this PR we are adding a efm-post-config hook, which might enable users to change efm config after tpa has set the config.
There are 2 main usecases:
- issues caused by TPA (see #248 for an example)
- refinement on EFM config, like setting a promotion order, or maybe other post config refinements
