### PR TITLE
ubuntu 24.04 support  for pem

### DIFF
--- a/roles/pem/server/pkg/defaults/main.yml
+++ b/roles/pem/server/pkg/defaults/main.yml
@@ -41,6 +41,7 @@ pem_server_modwsgi_package_name:
     "12": libapache2-mod-wsgi-py3
     "11": edb-python310-mod-wsgi
   Ubuntu:
+    "24": libapache2-mod-wsgi-py3
     "22": libapache2-mod-wsgi-py3
     "20": edb-python310-mod-wsgi
   SLES:


### PR DESCRIPTION
giving no package error on ubuntu 24